### PR TITLE
themes: GNOME 50 node coverage + build-time GTK4 %check

### DIFF
--- a/colloid-gtk-theme/colloid-gtk-theme.spec
+++ b/colloid-gtk-theme/colloid-gtk-theme.spec
@@ -1,6 +1,6 @@
 Name:           colloid-gtk-theme
 Version:        20250731
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        Theme for GNOME/GTK based desktop environments
 BuildArch:      noarch
 
@@ -10,15 +10,21 @@ License:        GPL-3.0-or-later
 %define dversion 2025-07-31
 URL:            https://github.com/vinceliuice/%{dname}
 Source0:        https://github.com/vinceliuice/%{dname}/archive/refs/tags/%{dversion}.tar.gz
+Patch0:         gnome50-selectors.patch
+Patch1:         gnome50-appearance.patch
+Patch2:         fix-fsf-address.patch
 
 BuildRequires:  gnome-shell
 BuildRequires:  sassc
+# %%check: validate the compiled GTK4 CSS with the real GTK engine
+BuildRequires:  gtk4
+BuildRequires:  python3-gobject-base
 
 %description
 Theme for GNOME/GTK based desktop environments.
 
 %prep
-%setup -q -n %{dname}-%{dversion}
+%autosetup -p1 -n %{dname}-%{dversion}
 
 %build
 # Prebuilt assets; nothing to compile (install.sh handles SASS).
@@ -27,10 +33,60 @@ Theme for GNOME/GTK based desktop environments.
 mkdir -p %{buildroot}%{_datarootdir}/themes
 ./install.sh -t grey --libadwaita --dest %{buildroot}%{_datarootdir}/themes
 
+%check
+# GTK 4.x build-time test: parse every installed gtk-4.0 stylesheet through the
+# real GTK CSS engine (GtkCssProvider) and fail on any genuine syntax error. The
+# benign base-resource @import ("resource:///org/gnome/theme/...") is ignored: it
+# only resolves at runtime inside a GTK application, not when linting standalone.
+python3 - <<'PYEOF'
+import gi, sys, glob
+gi.require_version("Gtk", "4.0")
+from gi.repository import Gtk
+real = 0
+cur = ""
+def on_err(prov, section, err):
+    global real
+    if "does not exist" in err.message:
+        return
+    loc = section.get_start_location()
+    sys.stderr.write("CSS ERROR " + cur + ":" + str(loc.lines + 1) + ": " + err.message + "\n")
+    real += 1
+files = sorted(glob.glob("%{buildroot}%{_datadir}/themes/*/gtk-4.0/*.css"))
+assert files, "no gtk-4.0 css found to validate"
+for cur in files:
+    prov = Gtk.CssProvider()
+    prov.connect("parsing-error", on_err)
+    prov.load_from_path(cur)
+print("GTK4 CSS parse check: " + str(len(files)) + " file(s), " + str(real) + " real error(s)")
+sys.exit(1 if real else 0)
+PYEOF
+# Shell node-gate: the GNOME 50 selectors must have compiled into gnome-shell.css
+for css in %{buildroot}%{_datadir}/themes/*/gnome-shell/gnome-shell.css; do
+  grep -q 'a11y-button' "$css" || { echo "node-gate FAIL: .a11y-button missing in $css"; exit 1; }
+  grep -q 'message-list-clear-button' "$css" || { echo "node-gate FAIL: .message-list-clear-button missing in $css"; exit 1; }
+done
+echo "shell node-gate: OK"
+
 %files
 %{_datarootdir}/themes
 
 %changelog
+* Sun Jun 21 2026 Hector Diaz <hdiazc@live.com> - 20250731-5
+- Patch0 (gnome50-selectors): style the GNOME 50 login .a11y-button and
+  notification .message-list-clear-button using the theme's own existing
+  styling (additive sibling selectors; inert on GNOME < 49)
+- Patch1 (gnome50-appearance): import GNOME 50 native geometry
+  (login-dialog-bottom-button-group 32px padding / 16px spacing,
+  message-list-clear-button pill border-radius)
+- Selector-correctness and SASS engine-parse verified; pixel appearance
+  not machine-verified
+- Patch2 (fix-fsf-address): update the outdated FSF postal address in the
+  upstream gnome-shell.css GPL header to the canonical URL form, clearing
+  rpmlint incorrect-fsf-address errors
+- Add a %%check: parse the compiled gtk-4.0 CSS with the real GTK 4 engine
+  (GtkCssProvider) and assert the GNOME 50 selectors compiled into
+  gnome-shell.css (new BuildRequires: gtk4, python3-gobject-base)
+
 * Sat May 16 2026 Hector Diaz <hdiazc@live.com> - 20250731-4
 - Drop GTK2-era runtime deps (adwaita-gtk2-theme, gtk-murrine-engine):
   adwaita-gtk2-theme was removed from Fedora 44 repos, and the gtk-2.0/

--- a/colloid-gtk-theme/fix-fsf-address.patch
+++ b/colloid-gtk-theme/fix-fsf-address.patch
@@ -1,0 +1,14 @@
+diff --git a/src/sass/gnome-shell/_common.scss b/src/sass/gnome-shell/_common.scss
+index 251878e3..03000f63 100644
+--- a/src/sass/gnome-shell/_common.scss
++++ b/src/sass/gnome-shell/_common.scss
+@@ -19,8 +19,7 @@ $cakeisalie: "This stylesheet is generated, DO NOT EDIT";
+  * more details.
+  *
+  * You should have received a copy of the GNU Lesser General Public License
+- * along with this program; if not, write to the Free Software Foundation,
+- * Inc., 51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
++ * along with this program; if not, see <http://www.gnu.org/licenses/>.
+  */
+ 
+ // Stage

--- a/colloid-gtk-theme/gnome50-appearance.patch
+++ b/colloid-gtk-theme/gnome50-appearance.patch
@@ -1,0 +1,25 @@
+diff --git a/src/sass/gnome-shell/common/_login-dialog.scss b/src/sass/gnome-shell/common/_login-dialog.scss
+index 2749a82e..0b298af7 100644
+--- a/src/sass/gnome-shell/common/_login-dialog.scss
++++ b/src/sass/gnome-shell/common/_login-dialog.scss
+@@ -174,3 +174,8 @@
+   @include fontsize($font_size + 1);
+   padding-top: 1em;
+ }
++
++.login-dialog-bottom-button-group {
++  padding: 32px;
++  spacing: 16px;
++}
+diff --git a/src/sass/gnome-shell/widgets-48-0/_message-list.scss b/src/sass/gnome-shell/widgets-48-0/_message-list.scss
+index 027bccc6..425468fb 100644
+--- a/src/sass/gnome-shell/widgets-48-0/_message-list.scss
++++ b/src/sass/gnome-shell/widgets-48-0/_message-list.scss
+@@ -268,3 +268,7 @@
+     }
+   }
+ }
++
++.message-list-controls .message-list-clear-button {
++  border-radius: 999px;
++}

--- a/colloid-gtk-theme/gnome50-selectors.patch
+++ b/colloid-gtk-theme/gnome50-selectors.patch
@@ -1,0 +1,26 @@
+diff --git a/src/sass/gnome-shell/common/_login-dialog.scss b/src/sass/gnome-shell/common/_login-dialog.scss
+index 9b748baf..2749a82e 100644
+--- a/src/sass/gnome-shell/common/_login-dialog.scss
++++ b/src/sass/gnome-shell/common/_login-dialog.scss
+@@ -50,6 +50,7 @@
+     }
+   }
+ 
++  .a11y-button,
+   .cancel-button,
+   .switch-user-button,
+   .login-dialog-session-list-button {
+diff --git a/src/sass/gnome-shell/widgets-48-0/_message-list.scss b/src/sass/gnome-shell/widgets-48-0/_message-list.scss
+index 5dfcf277..027bccc6 100644
+--- a/src/sass/gnome-shell/widgets-48-0/_message-list.scss
++++ b/src/sass/gnome-shell/widgets-48-0/_message-list.scss
+@@ -45,7 +45,8 @@
+   spacing: $base_padding;
+   @extend %heading;
+ 
+-  .dnd-button {
++  .dnd-button,
++  .message-list-clear-button {
+     // We need this because the focus outline isn't inset like for the buttons
+     // so the dnd button would grow when it gets focus if we didn't change only
+     // its color when focusing.

--- a/fluent-gtk-theme/fluent-gtk-theme-compact.spec
+++ b/fluent-gtk-theme/fluent-gtk-theme-compact.spec
@@ -1,6 +1,6 @@
 Name:           fluent-gtk-theme-compact
 Version:        20250417
-Release:        5%{?dist}
+Release:        6%{?dist}
 Summary:        Theme for GNOME/GTK based desktop environments
 BuildArch:      noarch
 
@@ -10,15 +10,20 @@ License:        GPL-3.0-or-later
 %define dversion 2025-04-17
 URL:            https://github.com/vinceliuice/%{dname}
 Source0:        https://github.com/vinceliuice/%{dname}/archive/refs/tags/%{dversion}.tar.gz
+Patch0:         gnome50-selectors.patch
+Patch1:         gnome50-appearance.patch
 
 BuildRequires:  gnome-shell
 BuildRequires:  sassc
+# %%check: validate the compiled GTK4 CSS with the real GTK engine
+BuildRequires:  gtk4
+BuildRequires:  python3-gobject-base
 
 %description
 Fluent is a Fluent design theme for GNOME/GTK based desktop environments
 
 %prep
-%setup -q -n %{dname}-%{dversion}
+%autosetup -p1 -n %{dname}-%{dversion}
 
 %build
 # Prebuilt assets; nothing to compile (install.sh handles SASS).
@@ -27,10 +32,60 @@ Fluent is a Fluent design theme for GNOME/GTK based desktop environments
 mkdir -p %{buildroot}%{_datarootdir}/themes
 ./install.sh --dest %{buildroot}%{_datarootdir}/themes --theme grey -i gnome --size compact --tweaks solid round -l
 
+%check
+# GTK 4.x build-time test: parse every installed gtk-4.0 stylesheet through the
+# real GTK CSS engine (GtkCssProvider) and fail on any genuine syntax error. The
+# benign base-resource @import ("resource:///org/gnome/theme/...") is ignored: it
+# only resolves at runtime inside a GTK application, not when linting standalone.
+python3 - <<'PYEOF'
+import gi, sys, glob
+gi.require_version("Gtk", "4.0")
+from gi.repository import Gtk
+real = 0
+cur = ""
+def on_err(prov, section, err):
+    global real
+    if "does not exist" in err.message:
+        return
+    loc = section.get_start_location()
+    sys.stderr.write("CSS ERROR " + cur + ":" + str(loc.lines + 1) + ": " + err.message + "\n")
+    real += 1
+files = sorted(glob.glob("%{buildroot}%{_datadir}/themes/*/gtk-4.0/*.css"))
+assert files, "no gtk-4.0 css found to validate"
+for cur in files:
+    prov = Gtk.CssProvider()
+    prov.connect("parsing-error", on_err)
+    prov.load_from_path(cur)
+print("GTK4 CSS parse check: " + str(len(files)) + " file(s), " + str(real) + " real error(s)")
+sys.exit(1 if real else 0)
+PYEOF
+# Shell node-gate: the GNOME 50 selectors must have compiled into gnome-shell.css
+for css in %{buildroot}%{_datadir}/themes/*/gnome-shell/gnome-shell.css; do
+  grep -q 'a11y-button' "$css" || { echo "node-gate FAIL: .a11y-button missing in $css"; exit 1; }
+  grep -q 'message-list-clear-button' "$css" || { echo "node-gate FAIL: .message-list-clear-button missing in $css"; exit 1; }
+done
+echo "shell node-gate: OK"
+
 %files
 %{_datarootdir}/themes
 
 %changelog
+* Sun Jun 21 2026 Hector Diaz <hdiazc@live.com> - 20250417-6
+- Patch0 (gnome50-selectors): style the GNOME 50 login .a11y-button and the
+  notification .message-list-clear-button with the theme's own button styling
+  by adding them as sibling selectors (.a11y-button to the login
+  .cancel-button group; .message-list-clear-button to the .dnd-button rule).
+  Additive only, inert on GNOME < 49 where the selectors do not exist.
+- Patch1 (gnome50-appearance): import GNOME 50's native geometry
+  (.login-dialog-bottom-button-group padding 32px / spacing 16px;
+  .message-list-clear-button pill border-radius 999px).
+- Switch %prep to %autosetup -p1 to apply the patches.
+- Appearance verified for selector-correctness and SCSS engine parse only,
+  not for pixel-level rendering.
+- Add a %%check: parse the compiled gtk-4.0 CSS with the real GTK 4 engine
+  (GtkCssProvider) and assert the GNOME 50 selectors compiled into
+  gnome-shell.css (new BuildRequires: gtk4, python3-gobject-base).
+
 * Sat May 16 2026 Hector Diaz <hdiazc@live.com> - 20250417-5
 - Drop GTK2-era runtime deps (adwaita-gtk2-theme, gtk-murrine-engine):
   adwaita-gtk2-theme was removed from Fedora 44 repos, and the gtk-2.0/

--- a/fluent-gtk-theme/gnome50-appearance.patch
+++ b/fluent-gtk-theme/gnome50-appearance.patch
@@ -1,0 +1,25 @@
+diff --git a/src/gnome-shell/sass/widgets/_login-dialog.scss b/src/gnome-shell/sass/widgets/_login-dialog.scss
+index b6dfc66..68964e7 100644
+--- a/src/gnome-shell/sass/widgets/_login-dialog.scss
++++ b/src/gnome-shell/sass/widgets/_login-dialog.scss
+@@ -149,3 +149,8 @@
+   font-size: 1em;
+   padding-top: 1em;
+ }
++
++.login-dialog-bottom-button-group {
++  padding: 32px;
++  spacing: 16px;
++}
+diff --git a/src/gnome-shell/sass/widgets/_message-list-48.scss b/src/gnome-shell/sass/widgets/_message-list-48.scss
+index f20f073..f2350eb 100644
+--- a/src/gnome-shell/sass/widgets/_message-list-48.scss
++++ b/src/gnome-shell/sass/widgets/_message-list-48.scss
+@@ -274,3 +274,7 @@
+     }
+   }
+ }
++
++.message-list-controls .message-list-clear-button {
++  border-radius: 999px;
++}

--- a/fluent-gtk-theme/gnome50-selectors.patch
+++ b/fluent-gtk-theme/gnome50-selectors.patch
@@ -1,0 +1,26 @@
+diff --git a/src/gnome-shell/sass/widgets/_login-dialog.scss b/src/gnome-shell/sass/widgets/_login-dialog.scss
+index d471ce3..b6dfc66 100644
+--- a/src/gnome-shell/sass/widgets/_login-dialog.scss
++++ b/src/gnome-shell/sass/widgets/_login-dialog.scss
+@@ -39,6 +39,7 @@
+     }
+   }
+ 
++  .a11y-button,
+   .cancel-button,
+   .switch-user-button,
+   .login-dialog-session-list-button {
+diff --git a/src/gnome-shell/sass/widgets/_message-list-48.scss b/src/gnome-shell/sass/widgets/_message-list-48.scss
+index c910a06..f20f073 100644
+--- a/src/gnome-shell/sass/widgets/_message-list-48.scss
++++ b/src/gnome-shell/sass/widgets/_message-list-48.scss
+@@ -57,7 +57,8 @@
+   padding-bottom: $container_padding;
+   spacing: $container_padding;
+   @extend %heading;
+-    .dnd-button {
++    .dnd-button,
++    .message-list-clear-button {
+     // We need this because the focus outline isn't inset like for the buttons
+     // so the dnd button would grow when it gets focus if we didn't change only
+     // its color when focusing.

--- a/qogir-theme/gnome50-appearance.patch
+++ b/qogir-theme/gnome50-appearance.patch
@@ -1,0 +1,25 @@
+diff --git a/src/_sass/gnome-shell/widgets-48-0/_message-list.scss b/src/_sass/gnome-shell/widgets-48-0/_message-list.scss
+index b6e1055..80c214d 100644
+--- a/src/_sass/gnome-shell/widgets-48-0/_message-list.scss
++++ b/src/_sass/gnome-shell/widgets-48-0/_message-list.scss
+@@ -307,3 +307,7 @@
+     }
+   }
+ }
++
++.message-list-controls .message-list-clear-button {
++  border-radius: 999px;
++}
+diff --git a/src/_sass/gnome-shell/widgets-common/_login-dialog.scss b/src/_sass/gnome-shell/widgets-common/_login-dialog.scss
+index 09a511c..fb0bda1 100644
+--- a/src/_sass/gnome-shell/widgets-common/_login-dialog.scss
++++ b/src/_sass/gnome-shell/widgets-common/_login-dialog.scss
+@@ -171,3 +171,8 @@
+     border-radius: 1000px;
+   }
+ }
++
++.login-dialog-bottom-button-group {
++  padding: 32px;
++  spacing: 16px;
++}

--- a/qogir-theme/gnome50-selectors.patch
+++ b/qogir-theme/gnome50-selectors.patch
@@ -1,0 +1,26 @@
+diff --git a/src/_sass/gnome-shell/widgets-48-0/_message-list.scss b/src/_sass/gnome-shell/widgets-48-0/_message-list.scss
+index a253fc7..b6e1055 100644
+--- a/src/_sass/gnome-shell/widgets-48-0/_message-list.scss
++++ b/src/_sass/gnome-shell/widgets-48-0/_message-list.scss
+@@ -43,7 +43,8 @@
+   spacing: $base_padding;
+   @extend %heading;
+ 
+-  .dnd-button {
++  .dnd-button,
++  .message-list-clear-button {
+     // We need this because the focus outline isn't inset like for the buttons
+     // so the dnd button would grow when it gets focus if we didn't change only
+     // its color when focusing.
+diff --git a/src/_sass/gnome-shell/widgets-common/_login-dialog.scss b/src/_sass/gnome-shell/widgets-common/_login-dialog.scss
+index c25376d..09a511c 100644
+--- a/src/_sass/gnome-shell/widgets-common/_login-dialog.scss
++++ b/src/_sass/gnome-shell/widgets-common/_login-dialog.scss
+@@ -35,6 +35,7 @@
+     }
+   }
+ 
++  .a11y-button,
+   .cancel-button,
+   .switch-user-button,
+   .login-dialog-session-list-button {

--- a/qogir-theme/qogir-theme.spec
+++ b/qogir-theme/qogir-theme.spec
@@ -1,6 +1,6 @@
 Name:           qogir-theme
 Version:        20250817
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        Theme for GNOME/GTK based desktop environments
 BuildArch:      noarch
 
@@ -10,9 +10,14 @@ License:        GPL-3.0-or-later
 %define dversion 2025-08-17
 URL:            https://github.com/vinceliuice/%{dname}
 Source0:        https://github.com/vinceliuice/%{dname}/archive/refs/tags/%{dversion}.tar.gz
+Patch0:         gnome50-selectors.patch
+Patch1:         gnome50-appearance.patch
 
 BuildRequires:  gnome-shell
 BuildRequires:  sassc
+# %%check: validate the compiled GTK4 CSS with the real GTK engine
+BuildRequires:  gtk4
+BuildRequires:  python3-gobject-base
 
 %description
 Qogir is a flat Design theme for GTK 3, GTK 2 
@@ -21,7 +26,7 @@ based desktop environments like Gnome, Unity, Budgie,
 Cinnamon Pantheon, XFCE, Mate, etc
 
 %prep
-%setup -q -n %{dname}-%{dversion}
+%autosetup -p1 -n %{dname}-%{dversion}
 
 %build
 # Prebuilt assets; nothing to compile (install.sh handles SASS).
@@ -30,10 +35,57 @@ Cinnamon Pantheon, XFCE, Mate, etc
 mkdir -p %{buildroot}%{_datarootdir}/themes
 ./install.sh --icon gnome --tweaks round --libadwaita --dest %{buildroot}%{_datarootdir}/themes
 
+%check
+# GTK 4.x build-time test: parse every installed gtk-4.0 stylesheet through the
+# real GTK CSS engine (GtkCssProvider) and fail on any genuine syntax error. The
+# benign base-resource @import ("resource:///org/gnome/theme/...") is ignored: it
+# only resolves at runtime inside a GTK application, not when linting standalone.
+python3 - <<'PYEOF'
+import gi, sys, glob
+gi.require_version("Gtk", "4.0")
+from gi.repository import Gtk
+real = 0
+cur = ""
+def on_err(prov, section, err):
+    global real
+    if "does not exist" in err.message:
+        return
+    loc = section.get_start_location()
+    sys.stderr.write("CSS ERROR " + cur + ":" + str(loc.lines + 1) + ": " + err.message + "\n")
+    real += 1
+files = sorted(glob.glob("%{buildroot}%{_datadir}/themes/*/gtk-4.0/*.css"))
+assert files, "no gtk-4.0 css found to validate"
+for cur in files:
+    prov = Gtk.CssProvider()
+    prov.connect("parsing-error", on_err)
+    prov.load_from_path(cur)
+print("GTK4 CSS parse check: " + str(len(files)) + " file(s), " + str(real) + " real error(s)")
+sys.exit(1 if real else 0)
+PYEOF
+# Shell node-gate: the GNOME 50 selectors must have compiled into gnome-shell.css
+for css in %{buildroot}%{_datadir}/themes/*/gnome-shell/gnome-shell.css; do
+  grep -q 'a11y-button' "$css" || { echo "node-gate FAIL: .a11y-button missing in $css"; exit 1; }
+  grep -q 'message-list-clear-button' "$css" || { echo "node-gate FAIL: .message-list-clear-button missing in $css"; exit 1; }
+done
+echo "shell node-gate: OK"
+
 %files
 %{_datarootdir}/themes
 
 %changelog
+* Sun Jun 21 2026 Hector Diaz <hdiazc@live.com> - 20250817-5
+- Patch0 (gnome50-selectors): style the GNOME 50 login .a11y-button and
+  notification .message-list-clear-button using the theme's own existing
+  styling (additive sibling selectors, inert on GNOME < 49)
+- Patch1 (gnome50-appearance): import GNOME 50 native geometry
+  (login-dialog-bottom-button-group 32px padding / 16px spacing,
+  message-list-clear-button pill border-radius)
+- Selector-correctness and SCSS engine-parse verified; pixel appearance
+  not machine-verified
+- Add a %%check: parse the compiled gtk-4.0 CSS with the real GTK 4 engine
+  (GtkCssProvider) and assert the GNOME 50 selectors compiled into
+  gnome-shell.css (new BuildRequires: gtk4, python3-gobject-base)
+
 * Sat May 16 2026 Hector Diaz <hdiazc@live.com> - 20250817-4
 - Drop GTK2-era runtime deps (adwaita-gtk2-theme, gtk-murrine-engine,
   gtk2-engines): adwaita-gtk2-theme was removed from Fedora 44 repos,

--- a/whitesur-gtk-theme/fix-fsf-address.patch
+++ b/whitesur-gtk-theme/fix-fsf-address.patch
@@ -1,0 +1,14 @@
+diff --git a/src/sass/gnome-shell/_common.scss b/src/sass/gnome-shell/_common.scss
+index f4290e11..fd731fab 100644
+--- a/src/sass/gnome-shell/_common.scss
++++ b/src/sass/gnome-shell/_common.scss
+@@ -19,8 +19,7 @@ $cakeisalie: "This stylesheet is generated, DO NOT EDIT";
+  * more details.
+  *
+  * You should have received a copy of the GNU Lesser General Public License
+- * along with this program; if not, write to the Free Software Foundation,
+- * Inc., 51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
++ * along with this program; if not, see <http://www.gnu.org/licenses/>.
+  */
+ 
+ // reset colors

--- a/whitesur-gtk-theme/gnome50-appearance.patch
+++ b/whitesur-gtk-theme/gnome50-appearance.patch
@@ -1,0 +1,28 @@
+diff --git a/src/sass/gnome-shell/common/_login-dialog.scss b/src/sass/gnome-shell/common/_login-dialog.scss
+index 719c68ac..302d9354 100644
+--- a/src/sass/gnome-shell/common/_login-dialog.scss
++++ b/src/sass/gnome-shell/common/_login-dialog.scss
+@@ -400,3 +400,10 @@
+ .login-dialog-prompt-label {
+   color: $light_hint_fg_color;
+ }
++
++// GNOME 50: container grouping the bottom-row login buttons (a11y, etc.).
++// Values ported from gnome-shell's own gnome-shell-sass/widgets/_login-lock.scss.
++.login-dialog-bottom-button-group {
++  padding: 32px;
++  spacing: 16px;
++}
+diff --git a/src/sass/gnome-shell/widgets-48-0/_message-list.scss b/src/sass/gnome-shell/widgets-48-0/_message-list.scss
+index a70470e3..bd892048 100644
+--- a/src/sass/gnome-shell/widgets-48-0/_message-list.scss
++++ b/src/sass/gnome-shell/widgets-48-0/_message-list.scss
+@@ -287,3 +287,8 @@ $card_bg_color: if($variant == 'light', mix(white, $bg_color, 95%), lighten($bas
+     }
+   }
+ }
++
++// GNOME 50: notification list "Clear" button gets the pill shape.
++.message-list-controls .message-list-clear-button {
++  border-radius: 999px;
++}

--- a/whitesur-gtk-theme/gnome50-selectors.patch
+++ b/whitesur-gtk-theme/gnome50-selectors.patch
@@ -1,5 +1,5 @@
 diff --git a/src/sass/gnome-shell/common/_login-dialog.scss b/src/sass/gnome-shell/common/_login-dialog.scss
-index bcd59d1..302d935 100644
+index bcd59d16..719c68ac 100644
 --- a/src/sass/gnome-shell/common/_login-dialog.scss
 +++ b/src/sass/gnome-shell/common/_login-dialog.scss
 @@ -50,6 +50,7 @@
@@ -26,14 +26,17 @@ index bcd59d1..302d935 100644
    .cancel-button,
    .switch-user-button,
    .login-dialog-session-list-button {
-@@ -397,3 +400,10 @@
- .login-dialog-prompt-label {
-   color: $light_hint_fg_color;
- }
-+
-+// GNOME 50: container grouping the bottom-row login buttons (a11y, etc.).
-+// Values ported from gnome-shell's own gnome-shell-sass/widgets/_login-lock.scss.
-+.login-dialog-bottom-button-group {
-+  padding: 32px;
-+  spacing: 16px;
-+}
+diff --git a/src/sass/gnome-shell/widgets-48-0/_message-list.scss b/src/sass/gnome-shell/widgets-48-0/_message-list.scss
+index 469454b0..a70470e3 100644
+--- a/src/sass/gnome-shell/widgets-48-0/_message-list.scss
++++ b/src/sass/gnome-shell/widgets-48-0/_message-list.scss
+@@ -45,7 +45,8 @@
+   spacing: $base_padding;
+   @extend %heading;
+ 
+-  .dnd-button {
++  .dnd-button,
++  .message-list-clear-button {
+     // We need this because the focus outline isn't inset like for the buttons
+     // so the dnd button would grow when it gets focus if we didn't change only
+     // its color when focusing.

--- a/whitesur-gtk-theme/whitesur-gtk-theme.spec
+++ b/whitesur-gtk-theme/whitesur-gtk-theme.spec
@@ -11,7 +11,7 @@ Name:           whitesur-gtk-theme
 # below any future upstream YYYYMMDD tag (all dated after today), so real
 # upstream updates still win. dname-shortcommit identifies the actual source.
 Version:        20260606
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Theme for GNOME/GTK based desktop environments
 BuildArch:      noarch
 
@@ -20,15 +20,24 @@ License:        GPL-3.0-or-later
 %define dname WhiteSur-gtk-theme
 URL:            https://github.com/vinceliuice/%{dname}
 Source0:        https://github.com/vinceliuice/%{dname}/archive/%{commit}.tar.gz#/%{dname}-%{shortcommit}.tar.gz
-# Downstream: style the new GNOME 50 login nodes (.a11y-button gains WhiteSur's
-# system-button look; .login-dialog-bottom-button-group spacing). Additive only
-# — these selectors don't exist pre-50, so the rules are inert on older shells.
-Patch0:         gnome50-login-selectors.patch
+# Downstream GNOME 50 styling, split into the uniform two-patch model shared with
+# the other vinceliuice themes. Patch0 (selectors) carries theme-native node
+# coverage: .a11y-button gains WhiteSur's login system-button look, and the
+# notification .message-list-clear-button is styled alongside .dnd-button. Patch1
+# (appearance) carries GNOME-native geometry: the .login-dialog-bottom-button-group
+# 32px/16px spacing and the .message-list-clear-button pill radius. Additive only —
+# these selectors don't exist pre-50, so the rules are inert on older shells.
+Patch0:         gnome50-selectors.patch
+Patch1:         gnome50-appearance.patch
+Patch2:         fix-fsf-address.patch
 
 BuildRequires:  glib2-devel
 BuildRequires:  gnome-shell
 BuildRequires:  sassc
 BuildRequires:  sudo
+# %%check: validate the compiled GTK4 CSS with the real GTK engine
+BuildRequires:  gtk4
+BuildRequires:  python3-gobject-base
 
 %description
 A macOS like theme for Linux GTK Desktops
@@ -43,10 +52,63 @@ A macOS like theme for Linux GTK Desktops
 mkdir -p %{buildroot}%{_datarootdir}/themes
 ./install.sh -t grey -N mojave -l --shell -i gnome --dest %{buildroot}%{_datarootdir}/themes
 
+%check
+# GTK 4.x build-time test: parse every installed gtk-4.0 stylesheet through the
+# real GTK CSS engine (GtkCssProvider) and fail on any genuine syntax error. The
+# benign base-resource @import ("resource:///org/gnome/theme/...") is ignored: it
+# only resolves at runtime inside a GTK application, not when linting standalone.
+python3 - <<'PYEOF'
+import gi, sys, glob
+gi.require_version("Gtk", "4.0")
+from gi.repository import Gtk
+real = 0
+cur = ""
+def on_err(prov, section, err):
+    global real
+    if "does not exist" in err.message:
+        return
+    loc = section.get_start_location()
+    sys.stderr.write("CSS ERROR " + cur + ":" + str(loc.lines + 1) + ": " + err.message + "\n")
+    real += 1
+files = sorted(glob.glob("%{buildroot}%{_datadir}/themes/*/gtk-4.0/*.css"))
+assert files, "no gtk-4.0 css found to validate"
+for cur in files:
+    prov = Gtk.CssProvider()
+    prov.connect("parsing-error", on_err)
+    prov.load_from_path(cur)
+print("GTK4 CSS parse check: " + str(len(files)) + " file(s), " + str(real) + " real error(s)")
+sys.exit(1 if real else 0)
+PYEOF
+# Shell node-gate: the GNOME 50 selectors must have compiled into gnome-shell.css
+for css in %{buildroot}%{_datadir}/themes/*/gnome-shell/gnome-shell.css; do
+  grep -q 'a11y-button' "$css" || { echo "node-gate FAIL: .a11y-button missing in $css"; exit 1; }
+  grep -q 'message-list-clear-button' "$css" || { echo "node-gate FAIL: .message-list-clear-button missing in $css"; exit 1; }
+done
+echo "shell node-gate: OK"
+
 %files
 %{_datarootdir}/themes
 
 %changelog
+* Sun Jun 21 2026 Hector Diaz <hdiazc@live.com> - 20260606-2
+- Split the single GNOME 50 login patch into the uniform two-patch model now
+  shared with the other vinceliuice themes (fluent/colloid/qogir):
+  gnome50-selectors.patch (theme-native node coverage: the .a11y-button login
+  buttons plus the newly-added notification .message-list-clear-button styled
+  alongside .dnd-button) and gnome50-appearance.patch (GNOME 50 native geometry:
+  the .login-dialog-bottom-button-group 32px/16px spacing and the
+  .message-list-clear-button pill border-radius: 999px).
+- Adds the notification clear-button coverage WhiteSur previously lacked.
+- Additive/inert on GNOME < 49 (these selectors don't exist there).
+  Selector-correctness and SASS engine-parse verified; pixel appearance on a
+  live GNOME 50 session not machine-verified.
+- Patch2 (fix-fsf-address): update the outdated FSF postal address in the
+  upstream gnome-shell.css GPL header to the canonical URL form, clearing
+  rpmlint incorrect-fsf-address errors.
+- Add a %%check: parse the compiled gtk-4.0 CSS with the real GTK 4 engine
+  (GtkCssProvider) and assert the GNOME 50 selectors compiled into
+  gnome-shell.css (new BuildRequires: gtk4, python3-gobject-base).
+
 * Sat Jun 06 2026 Hector Diaz <hdiazc@live.com> - 20260606-1
 - Rebase onto a pinned upstream master snapshot (commit a83f467e, 2026-05-25),
   50 commits past the last tag (2025-07-24). This pulls in upstream's own


### PR DESCRIPTION
Audit found all four vinceliuice themes (fluent/colloid/qogir/whitesur) clamp GNOME shells >=48 to the 48-era stylesheet, leaving the new GNOME 50 shell nodes unstyled (verified by diffing each theme's selectors against GNOME 50.2's own gnome-shell-theme.gresource on Fedora 44). No upstream tag, master commit, or fork carries a fix.

Per theme, two additive patches (inert on GNOME < 49):
- gnome50-selectors.patch: theme-native styling for .a11y-button (login) and .message-list-clear-button (notification, replaces the dead .dnd-button).
- gnome50-appearance.patch: GNOME 50 native geometry (.login-dialog-bottom-button-group 32px/16px, clear-button pill radius).

WhiteSur's single login patch is refactored into this uniform two-patch model and gains the notification clear-button coverage it lacked (login styling proven byte-identical via blob hash).

Add a %check to every spec (BuildRequires: gtk4, python3-gobject-base): parse the compiled gtk-4.0 CSS with the real GTK 4 engine (GtkCssProvider, runs headless in mock) and assert the GNOME 50 selectors compiled into gnome-shell.css. colloid/whitesur also get fix-fsf-address.patch, clearing rpmlint incorrect-fsf-address errors in the upstream GPL header.

Verified: mock fc44 build exit 0, %check passing, rpmlint 0 errors, GTK4 parse 0 errors across all four.