### PR TITLE
orchis-theme: GNOME 50 node coverage + GTK4 %check + GTK 4.22 fix

### DIFF
--- a/orchis-theme/fix-gtk4-define-color.patch
+++ b/orchis-theme/fix-gtk4-define-color.patch
@@ -1,0 +1,22 @@
+diff --git a/src/_sass/gtk/_colors-public.scss b/src/_sass/gtk/_colors-public.scss
+index cc2de909..5b9bed10 100644
+--- a/src/_sass/gtk/_colors-public.scss
++++ b/src/_sass/gtk/_colors-public.scss
+@@ -23,7 +23,7 @@ text widgets and the like base background color */
+ 
+ /*
+ base background color of selections */
+-@define-color theme_selected_bg_color #{"" + $primary};
++@define-color theme_selected_bg_color #{if(type-of($primary) == color, "" + $primary, "@accent_color")};
+ 
+ /*
+ text/foreground color of selections */
+@@ -59,7 +59,7 @@ text widgets and the like base background color on backdrop windows */
+ 
+ /*
+ base background color of selections on backdrop windows */
+-@define-color theme_unfocused_selected_bg_color #{"" + $primary};
++@define-color theme_unfocused_selected_bg_color #{if(type-of($primary) == color, "" + $primary, "@accent_color")};
+ 
+ /*
+ text/foreground color of selections on backdrop windows */

--- a/orchis-theme/gnome50-appearance.patch
+++ b/orchis-theme/gnome50-appearance.patch
@@ -1,0 +1,25 @@
+diff --git a/src/_sass/gnome-shell/widgets/_login-dialog.scss b/src/_sass/gnome-shell/widgets/_login-dialog.scss
+index de12b6f3..19eaa258 100644
+--- a/src/_sass/gnome-shell/widgets/_login-dialog.scss
++++ b/src/_sass/gnome-shell/widgets/_login-dialog.scss
+@@ -148,3 +148,8 @@
+   font-size: 1em;
+   padding-top: 1em;
+ }
++
++.login-dialog-bottom-button-group {
++  padding: 32px;
++  spacing: 16px;
++}
+diff --git a/src/_sass/gnome-shell/widgets/_message-list-48.scss b/src/_sass/gnome-shell/widgets/_message-list-48.scss
+index e4c9af7a..753b7920 100644
+--- a/src/_sass/gnome-shell/widgets/_message-list-48.scss
++++ b/src/_sass/gnome-shell/widgets/_message-list-48.scss
+@@ -257,3 +257,7 @@
+     }
+   }
+ }
++
++.message-list-controls .message-list-clear-button {
++  border-radius: 999px;
++}

--- a/orchis-theme/gnome50-selectors.patch
+++ b/orchis-theme/gnome50-selectors.patch
@@ -1,0 +1,26 @@
+diff --git a/src/_sass/gnome-shell/widgets/_login-dialog.scss b/src/_sass/gnome-shell/widgets/_login-dialog.scss
+index c532bb4b..de12b6f3 100644
+--- a/src/_sass/gnome-shell/widgets/_login-dialog.scss
++++ b/src/_sass/gnome-shell/widgets/_login-dialog.scss
+@@ -38,6 +38,7 @@
+     }
+   }
+ 
++  .a11y-button,
+   .cancel-button,
+   .switch-user-button,
+   .login-dialog-session-list-button {
+diff --git a/src/_sass/gnome-shell/widgets/_message-list-48.scss b/src/_sass/gnome-shell/widgets/_message-list-48.scss
+index c2e981b6..e4c9af7a 100644
+--- a/src/_sass/gnome-shell/widgets/_message-list-48.scss
++++ b/src/_sass/gnome-shell/widgets/_message-list-48.scss
+@@ -46,7 +46,8 @@
+   spacing: $space-size * 2;
+   @extend %heading;
+ 
+-  .dnd-button {
++  .dnd-button,
++  .message-list-clear-button {
+     // We need this because the focus outline isn't inset like for the buttons
+     // so the dnd button would grow when it gets focus if we didn't change only
+     // its color when focusing.

--- a/orchis-theme/orchis-theme.spec
+++ b/orchis-theme/orchis-theme.spec
@@ -1,6 +1,6 @@
 Name:           orchis-theme
 Version:        20250425
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        Theme for GNOME/GTK based desktop environments
 BuildArch:      noarch
 
@@ -10,16 +10,22 @@ License:        GPL-3.0-or-later
 %define dversion 2025-04-25
 URL:            https://github.com/vinceliuice/%{dname}
 Source0:        https://github.com/vinceliuice/%{dname}/archive/refs/tags/%{dversion}.tar.gz
+Patch0:         gnome50-selectors.patch
+Patch1:         gnome50-appearance.patch
+Patch2:         fix-gtk4-define-color.patch
 
 BuildRequires:  gnome-shell
 BuildRequires:  sassc
+# %%check: validate the compiled GTK4 CSS with the real GTK engine
+BuildRequires:  gtk4
+BuildRequires:  python3-gobject-base
 
 %description
 Orchis is a Material Design theme for GNOME/GTK based desktop environments.
 Based on nana-4 -- materia-theme
 
 %prep
-%setup -q -n %{dname}-%{dversion}
+%autosetup -p1 -n %{dname}-%{dversion}
 
 %build
 # Prebuilt assets; nothing to compile (install.sh handles SASS).
@@ -28,10 +34,65 @@ Based on nana-4 -- materia-theme
 mkdir -p %{buildroot}%{_datarootdir}/themes
 ./install.sh --icon gnome -t grey -c dark --libadwaita --dest %{buildroot}%{_datarootdir}/themes
 
+%check
+# GTK 4.x build-time test: parse every installed gtk-4.0 stylesheet through the
+# real GTK CSS engine (GtkCssProvider) and fail on any genuine syntax error. The
+# benign base-resource @import ("resource:///org/gnome/theme/...") is ignored: it
+# only resolves at runtime inside a GTK application, not when linting standalone.
+python3 - <<'PYEOF'
+import gi, sys, glob
+gi.require_version("Gtk", "4.0")
+from gi.repository import Gtk
+real = 0
+cur = ""
+def on_err(prov, section, err):
+    global real
+    if "does not exist" in err.message:
+        return
+    loc = section.get_start_location()
+    sys.stderr.write("CSS ERROR " + cur + ":" + str(loc.lines + 1) + ": " + err.message + "\n")
+    real += 1
+files = sorted(glob.glob("%{buildroot}%{_datadir}/themes/*/gtk-4.0/*.css"))
+assert files, "no gtk-4.0 css found to validate"
+for cur in files:
+    prov = Gtk.CssProvider()
+    prov.connect("parsing-error", on_err)
+    prov.load_from_path(cur)
+print("GTK4 CSS parse check: " + str(len(files)) + " file(s), " + str(real) + " real error(s)")
+sys.exit(1 if real else 0)
+PYEOF
+# Shell node-gate: the GNOME 50 selectors must have compiled into gnome-shell.css
+for css in %{buildroot}%{_datadir}/themes/*/gnome-shell/gnome-shell.css; do
+  grep -q 'a11y-button' "$css" || { echo "node-gate FAIL: .a11y-button missing in $css"; exit 1; }
+  grep -q 'message-list-clear-button' "$css" || { echo "node-gate FAIL: .message-list-clear-button missing in $css"; exit 1; }
+done
+echo "shell node-gate: OK"
+
 %files
 %{_datarootdir}/themes
 
 %changelog
+* Sun Jun 21 2026 Hector Diaz <hdiazc@live.com> - 20250425-5
+- Patch0 (gnome50-selectors): style the GNOME 50 login .a11y-button and
+  notification .message-list-clear-button using the theme's own existing
+  styling (additive sibling selectors, inert on GNOME < 49)
+- Patch1 (gnome50-appearance): import GNOME 50 native geometry
+  (login-dialog-bottom-button-group 32px padding / 16px spacing,
+  message-list-clear-button pill border-radius)
+- Switch %%prep to %%autosetup -p1
+- Add a %%check: parse the compiled gtk-4.0 CSS with the real GTK 4 engine
+  (GtkCssProvider) and assert the GNOME 50 selectors compiled into
+  gnome-shell.css (new BuildRequires: gtk4, python3-gobject-base)
+- Selector-correctness and engine-parse verified; pixel appearance
+  not machine-verified
+- Patch2 (fix-gtk4-define-color): fix a pre-existing GTK 4 parse error the
+  %%check surfaced. The libadwaita build emitted
+  "@define-color theme_{,unfocused_}selected_bg_color var(--accent-bg-color)",
+  which GTK's @define-color cannot parse ("Expected a valid color"). Use the
+  defined @accent_color named color in the libadwaita case only (guarded by
+  type-of($primary)), leaving the valid GTK3 literal untouched. Verified 0 GTK4
+  parse errors via the real engine; present in upstream master too.
+
 * Sat May 16 2026 Hector Diaz <hdiazc@live.com> - 20250425-4
 - Drop GTK2-era runtime deps (adwaita-gtk2-theme, gtk-murrine-engine):
   adwaita-gtk2-theme was removed from Fedora 44 repos, and the gtk-2.0/


### PR DESCRIPTION
Apply the same GNOME 50 treatment as the other vinceliuice themes: Orchis clamps shells >=48 to the 48-era stylesheet, leaving the new GNOME 50 nodes unstyled (verified against GNOME 50.2's gnome-shell-theme.gresource).

- gnome50-selectors.patch: theme-native .a11y-button (login) and .message-list-clear-button (notification, replaces dead .dnd-button).
- gnome50-appearance.patch: GNOME 50 native geometry (.login-dialog-bottom-button-group 32px/16px, clear-button pill radius).
- Add the GTK4 %check (BuildRequires: gtk4, python3-gobject-base): real GTK 4 engine parse of gtk-4.0 CSS + shell node-gate.
- fix-gtk4-define-color.patch: the %check surfaced a pre-existing GTK 4.22 parse error (libadwaita build emitted @define-color ... var(--accent-bg-color), which GTK's @define-color cannot parse). Reference the defined @accent_color in the libadwaita case only (guarded by type-of($primary)); the valid GTK3 literal is untouched. Present in upstream master too.

Verified: mock fc44 exit 0, %check passing (GTK4 0 parse errors, node-gate OK), GTK3 selected-bg literal unchanged. Spelling-error rpmlint E's are pre-existing false positives on the proper nouns nana-4/materia-theme in %description.