### PR TITLE
docs: add CLAUDE.md, sync README with GNOME 50 theme changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,68 @@
+# CLAUDE.md
+
+RPM spec files for Fedora 44, built in the raro28/wdm COPR. One subdirectory per
+source package. See README.md for per-spec build details.
+
+## Verify, don't assert (governing rule)
+- State only analytically verified facts. Back every claim with evidence — a
+  command's output, a file's contents, an engine/build result — never memory,
+  assumption, or "should work."
+- "Verified" means reproduced on this host: build it (`mock` exit 0), parse it
+  (real GTK engine), diff it against ground truth (`gresource extract`), grep the
+  actual compiled output. A plan is not a result.
+- Derive from the reference implementation present on this host (GNOME 50.2,
+  GTK 4.22) — not from training data or upstream READMEs.
+- When something is unverified or unverifiable (e.g. live pixel rendering), say so
+  explicitly; never imply it was checked.
+- No silent scope: report what you ran, what passed, and what you skipped.
+- Prefer upstream/fork fixes you can verify over hand-authored guesses; if you
+  must author a fix, prove it with the engine/build before claiming it works.
+
+## Style: terse and factual
+- Write factually, no filler — in prose, spec files, `%changelog` entries, and
+  comments alike. No marketing, no hedging, no restating the obvious.
+- Keep edits minimal; match the surrounding file's brevity and idiom. State what
+  changed and why in as few words as the fact needs.
+
+## Build / verify loop
+- Target = Fedora 44 (GNOME 50.2, GTK 4.22); build in a clean chroot.
+- Flow: `spectool -g -R <spec>` → `rpmbuild -bs <spec>` →
+  `mock -r fedora-44-x86_64 <srpm>`. Output in `/var/lib/mock/fedora-44-x86_64/result/`.
+- mock reads `~/rpmbuild/SOURCES/` (the `spectool` step populates URL sources); stage
+  local patches there first (`cp <dir>/*.patch ~/rpmbuild/SOURCES/`).
+- Lint gate: `rpmlint -c rpmlint.toml */*.spec` must report `0 errors, 0 warnings`
+  before work is done.
+
+## Spec conventions
+- Downstream patch / packaging change → bump `Release`, keep upstream `Version`.
+  Change `Version` only when the upstream source changes.
+- Use `%autosetup -p1` (not `%setup`) when `PatchN:` is present.
+- `%changelog`: escape macros as `%%` (e.g. `%%autosetup`); entry header
+  `* Day Mon DD YYYY Name <email> - VERSION-RELEASE`.
+- Patch files live in the spec's subdirectory, named by purpose.
+
+## Keep README.md in sync
+When a spec changes, update README.md in the same change, then re-check the lint
+gate. Spots that drift:
+- Specs table — `Version-Release` and "what it ships".
+- The per-spec build section — staged sources and the `<srpm>` filename.
+- Quick-reference table — local/URL sources.
+- Linting section — `%check`/filter counts.
+
+## vinceliuice GTK themes (colloid/fluent/orchis/qogir/whitesur)
+- install.sh clamps GNOME shells ≥48 to the 48-era stylesheet
+  (`shell-48-0`/`widgets-48-0`), leaving GNOME 50 nodes unstyled; downstream
+  patches add coverage (README → "vinceliuice GTK themes").
+- Each carries a `%check` (`BuildRequires: gtk4 python3-gobject-base`): parses
+  compiled `gtk-4.0` CSS via `GtkCssProvider` (headless in mock) and greps the
+  GNOME 50 selectors in `gnome-shell.css`.
+- GNOME 50 ground truth (from this host): shell nodes from
+  `/usr/share/gnome-shell/gnome-shell-theme.gresource`; libadwaita CSS from
+  `/usr/lib64/libadwaita-1.so.0` (both via `gresource extract`).
+
+## Environment
+- An `rtk` hook rewrites shell commands. Generate patches with `rtk proxy git diff`
+  — plain filtered output is not a valid applyable diff.
+
+## Git
+- Default working branch: `develop` (PRs target `main`). Commit/push only when asked.

--- a/README.md
+++ b/README.md
@@ -8,18 +8,18 @@ Each subdirectory is one source package.
 
 | Spec | Current build | What it ships |
 |---|---|---|
-| colloid-gtk-theme | `20250731-4` | GTK theme (vinceliuice) |
-| fluent-gtk-theme-compact | `20250417-5` | GTK theme (vinceliuice) |
+| colloid-gtk-theme | `20250731-5` | GTK theme (vinceliuice), GNOME 50 patches |
+| fluent-gtk-theme-compact | `20250417-6` | GTK theme (vinceliuice), GNOME 50 patches |
 | gnome-shell-extension-per-monitor-wallpaper | `1.0.1-1` | GNOME Shell extension, per-monitor wallpapers (raro28) |
 | llama.cpp | `0^b9544-1` | LLM inference, Vulkan backend + embedded web UI (ggml-org/llama.cpp) |
 | looking-glass-client | `7.0.0-14` | Looking Glass B7 client + SELinux subpackage |
 | looking-glass-kvmfr-kmod | `0.0.12-7` | akmod for the `kvmfr` kernel module — see [its README](looking-glass-kvmfr-kmod/README.md) |
-| orchis-theme | `20250425-4` | GTK theme (vinceliuice) |
+| orchis-theme | `20250425-5` | GTK theme (vinceliuice), GNOME 50 patches |
 | qogir-icon-theme | `20250215-3` | Icon theme (vinceliuice) |
-| qogir-theme | `20250817-4` | GTK theme (vinceliuice) |
+| qogir-theme | `20250817-5` | GTK theme (vinceliuice), GNOME 50 patches |
 | tela-circle-icon-theme | `20250210-3` | Icon theme (vinceliuice) |
 | tela-icon-theme | `20250210-1` | Icon theme (vinceliuice) |
-| whitesur-gtk-theme | `20260606-1` | GTK theme (vinceliuice, GNOME 50 master snapshot) |
+| whitesur-gtk-theme | `20260606-2` | GTK theme (vinceliuice), GNOME 50 master snapshot + patches |
 | whitesur-icon-theme | `20251227-1` | Icon theme (vinceliuice) |
 
 ## Host setup (once)
@@ -69,48 +69,51 @@ sudo dnf install /var/lib/mock/fedora-44-x86_64/result/*.rpm
 
 ### Pure-upstream specs (no local sources)
 
-Eight of the nine vinceliuice theme/icon specs have only `Source0` (a GitHub tarball); `whitesur-gtk-theme` is the exception — it pins a master snapshot and carries a local patch, so it has its own section below. The `per-monitor-wallpaper` GNOME extension is likewise pure-upstream `Source0` only. For all of these the workflow is the canonical 4 steps; nothing to copy.
+`Source0` (GitHub tarball) only; canonical 4 steps, nothing to copy:
 
-Example with `qogir-theme`:
-
-```bash
-spectool -g -R qogir-theme/qogir-theme.spec
-rpmbuild -bs qogir-theme/qogir-theme.spec
-mock -r fedora-44-x86_64 ~/rpmbuild/SRPMS/qogir-theme-20250817-4.fc44.src.rpm
-```
-
-Substitute the spec path / SRPM filename for any of:
-
-- `colloid-gtk-theme`
-- `fluent-gtk-theme-compact`
 - `gnome-shell-extension-per-monitor-wallpaper`
-- `orchis-theme`
 - `qogir-icon-theme`
-- `qogir-theme`
 - `tela-circle-icon-theme`
 - `tela-icon-theme`
 - `whitesur-icon-theme`
 
-`gnome-shell-extension-per-monitor-wallpaper` installs system-wide; each user then enables it with `gnome-extensions enable per-monitor-wallpaper@ekthor`. It requires GNOME Shell 50.x (pinned via a versioned `Requires`) and is pure GJS, so it has no `BuildRequires`.
-
-### whitesur-gtk-theme
-
-Built from a pinned `master` snapshot (`%global commit`) rather than the last upstream tag (`20250724`), which predates GNOME 49/50. The snapshot is date-versioned `20260606` so a future real upstream `YYYYMMDD` tag still sorts above and supersedes it.
-
-**Local source** to stage before `spectool` — `Source0` is a URL but the downstream patch is a local file that must be in `SOURCES/`:
-
+```bash
+spectool -g -R qogir-icon-theme/qogir-icon-theme.spec
+rpmbuild -bs qogir-icon-theme/qogir-icon-theme.spec
+mock -r fedora-44-x86_64 ~/rpmbuild/SRPMS/qogir-icon-theme-20250215-3.fc44.src.rpm
 ```
-whitesur-gtk-theme/gnome50-login-selectors.patch
-```
+
+`gnome-shell-extension-per-monitor-wallpaper` installs system-wide; each user enables it with `gnome-extensions enable per-monitor-wallpaper@ekthor`. Requires GNOME Shell 50.x (versioned `Requires`); pure GJS, no `BuildRequires`.
+
+### vinceliuice GTK themes (GNOME 50 patches)
+
+`colloid-gtk-theme`, `fluent-gtk-theme-compact`, `orchis-theme`, `qogir-theme`, `whitesur-gtk-theme`. Each carries downstream GNOME 50 patches (local files, stage in `SOURCES/`) and a `%check` (GTK 4 CSS engine parse via `GtkCssProvider` + shell selector node-gate; `BuildRequires: gtk4 python3-gobject-base`, auto-installed in the chroot).
+
+| Spec | Patches |
+|---|---|
+| colloid-gtk-theme | gnome50-selectors, gnome50-appearance, fix-fsf-address |
+| fluent-gtk-theme-compact | gnome50-selectors, gnome50-appearance |
+| orchis-theme | gnome50-selectors, gnome50-appearance, fix-gtk4-define-color |
+| qogir-theme | gnome50-selectors, gnome50-appearance |
+| whitesur-gtk-theme | gnome50-selectors, gnome50-appearance, fix-fsf-address |
+
+Stage the patches with the glob, then build. Example (`qogir-theme`):
 
 ```bash
-cp whitesur-gtk-theme/gnome50-login-selectors.patch ~/rpmbuild/SOURCES/
-spectool -g -R whitesur-gtk-theme/whitesur-gtk-theme.spec
-rpmbuild -bs whitesur-gtk-theme/whitesur-gtk-theme.spec
-mock -r fedora-44-x86_64 ~/rpmbuild/SRPMS/whitesur-gtk-theme-20260606-1.fc44.src.rpm
+cp qogir-theme/*.patch ~/rpmbuild/SOURCES/
+spectool -g -R qogir-theme/qogir-theme.spec
+rpmbuild -bs qogir-theme/qogir-theme.spec
+mock -r fedora-44-x86_64 ~/rpmbuild/SRPMS/qogir-theme-20250817-5.fc44.src.rpm
 ```
 
-To advance the snapshot, update `%global commit` in the spec; switch back to a plain dated tag once upstream cuts a release with GNOME 49/50 support.
+Patch reference:
+
+- `gnome50-selectors.patch` — styles GNOME 50 login `.a11y-button` and notification `.message-list-clear-button` with the theme's own button styling (additive sibling selectors, inert on GNOME < 49).
+- `gnome50-appearance.patch` — GNOME 50 native geometry: `.login-dialog-bottom-button-group` 32px/16px, `.message-list-clear-button` `border-radius: 999px`.
+- `fix-fsf-address.patch` (colloid, whitesur) — replaces the outdated FSF postal address in the upstream `gnome-shell.css` GPL header with the canonical URL form (clears rpmlint `incorrect-fsf-address`).
+- `fix-gtk4-define-color.patch` (orchis) — the libadwaita build emitted `@define-color theme_{,unfocused_}selected_bg_color var(--accent-bg-color)`, which GTK's `@define-color` rejects; references the defined `@accent_color` in the libadwaita case only (the GTK3 literal is untouched).
+
+`whitesur-gtk-theme` additionally builds from a pinned `master` snapshot (`%global commit`) rather than the last tag (`20250724`, predates GNOME 49/50), date-versioned `20260606` so a future upstream `YYYYMMDD` tag supersedes it. Advance via `%global commit`.
 
 ### llama.cpp
 
@@ -192,10 +195,10 @@ After installing, `/dev/kvmfr0` needs **two manual host configuration steps** (l
 
 | Spec | Local sources? | URL sources? |
 |---|---|---|
-| 8 vinceliuice theme/icon specs | No | Source0 only |
+| 4 vinceliuice icon themes | No | Source0 only |
 | gnome-shell-extension-per-monitor-wallpaper | No | Source0 only |
 | llama.cpp | No | Source0 + Source1 (web-UI bundle) |
-| whitesur-gtk-theme | **Yes** — 1 patch | Source0 only |
+| 5 vinceliuice GTK themes | **Yes** — 2–3 patches | Source0 only |
 | looking-glass-client | **Yes** — 4 files | Source0 + 6 submodule URLs |
 | looking-glass-kvmfr-kmod | **Yes** — 5 files + 1 patch | Source0 only |
 
@@ -212,19 +215,20 @@ rpmlint -c rpmlint.toml */*.spec
 # expect: 0 errors, 0 warnings, 0 badness
 ```
 
-The `-c rpmlint.toml` flag is required — it adds two repo-local filters on top of
-Fedora's defaults:
+`-c rpmlint.toml` adds two repo-local filters on top of Fedora's defaults:
 
-- `no-%check-section` — suppressed for the specs with no upstream test suite (the
-  theme/icon packages, the kvmfr akmod, and the GJS extension); a no-op `%check`
-  would test nothing.
+- `no-%check-section` — suppressed for the 6 specs with no test to run (the 4
+  icon themes, the kvmfr akmod, the GJS extension). The 5 vinceliuice GTK themes,
+  llama.cpp, and looking-glass-client carry a real `%check`.
 - `spelling-error '(json|ekthor)'` — `json` (part of `config.json`) and `ekthor`
   (the extension's UUID author tag) are correct, not misspellings.
 
-Every other warning class is fixed in the specs themselves (`%setup -q`, an
-explicit `%build`, and `%%`-escaped macros in `%changelog`), so a plain
-`rpmlint */*.spec` only ever surfaces the deliberately-filtered
-`no-%check-section` (11 specs, verified).
+The GTK-theme `%check` parses the compiled `gtk-4.0` CSS through the real GTK 4
+engine (`GtkCssProvider`) and asserts the GNOME 50 selectors compiled into
+`gnome-shell.css`. Every other warning class is fixed in the specs
+(`%setup -q`/`%autosetup`, an explicit `%build`, `%%`-escaped `%changelog`
+macros), so a plain `rpmlint */*.spec` only surfaces the filtered
+`no-%check-section` (6 specs).
 
 ## COPR
 

--- a/fluent-gtk-theme/fluent-gtk-theme-compact.spec
+++ b/fluent-gtk-theme/fluent-gtk-theme-compact.spec
@@ -79,7 +79,7 @@ echo "shell node-gate: OK"
 - Patch1 (gnome50-appearance): import GNOME 50's native geometry
   (.login-dialog-bottom-button-group padding 32px / spacing 16px;
   .message-list-clear-button pill border-radius 999px).
-- Switch %prep to %autosetup -p1 to apply the patches.
+- Switch %%prep to %%autosetup -p1 to apply the patches.
 - Appearance verified for selector-correctness and SCSS engine parse only,
   not for pixel-level rendering.
 - Add a %%check: parse the compiled gtk-4.0 CSS with the real GTK 4 engine


### PR DESCRIPTION
- CLAUDE.md: agent guide — verify-don't-assert rule, terse-style rule, build/verify loop, spec conventions, README-sync checklist, GTK-theme GNOME 50 specifics, rtk/git notes.
- README: bump the 5 GTK theme Version-Releases; replace the pure-upstream framing with a "vinceliuice GTK themes (GNOME 50 patches)" section (per-theme patch list, %check, staging); update the quick-reference and Linting sections (no-%check-section now 6 specs).
- fluent changelog: %%-escape %prep/%autosetup (restores rpmlint 0/0/0).