### PR TITLE
gnome-shell-extension-per-monitor-wallpaper: 1.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Each subdirectory is one source package.
 |---|---|---|
 | colloid-gtk-theme | `20250731-5` | GTK theme ([vinceliuice/Colloid-gtk-theme](https://github.com/vinceliuice/Colloid-gtk-theme)), GNOME 50 patches |
 | fluent-gtk-theme-compact | `20250417-6` | GTK theme ([vinceliuice/Fluent-gtk-theme](https://github.com/vinceliuice/Fluent-gtk-theme)), GNOME 50 patches |
-| gnome-shell-extension-per-monitor-wallpaper | `1.0.1-1` | GNOME Shell extension, per-monitor wallpapers ([raro28/per-monitor-wallpaper](https://github.com/raro28/per-monitor-wallpaper)) |
+| gnome-shell-extension-per-monitor-wallpaper | `1.0.2-1` | GNOME Shell extension, per-monitor wallpapers ([raro28/per-monitor-wallpaper](https://github.com/raro28/per-monitor-wallpaper)) |
 | llama.cpp | `0^b9544-1` | LLM inference, Vulkan backend + embedded web UI ([ggml-org/llama.cpp](https://github.com/ggml-org/llama.cpp)) |
 | looking-glass-client | `7.0.0-14` | Looking Glass B7 client + SELinux subpackage ([gnif/LookingGlass](https://github.com/gnif/LookingGlass)) |
 | looking-glass-kvmfr-kmod | `0.0.12-7` | akmod for the `kvmfr` kernel module ([gnif/LookingGlass](https://github.com/gnif/LookingGlass)) — see [its README](looking-glass-kvmfr-kmod/README.md) |

--- a/gnome-shell-extension-per-monitor-wallpaper/gnome-shell-extension-per-monitor-wallpaper.spec
+++ b/gnome-shell-extension-per-monitor-wallpaper/gnome-shell-extension-per-monitor-wallpaper.spec
@@ -2,7 +2,7 @@
 %global uuid    per-monitor-wallpaper@ekthor
 
 Name:           gnome-shell-extension-per-monitor-wallpaper
-Version:        1.0.1
+Version:        1.0.2
 Release:        1%{?dist}
 Summary:        GNOME Shell extension that paints each monitor its own wallpaper
 BuildArch:      noarch
@@ -45,6 +45,10 @@ install -pm 0644 src/metadata.json src/extension.js \
 %{_datadir}/gnome-shell/extensions/%{uuid}/
 
 %changelog
+* Sun Jun 21 2026 Hector Diaz <hdiazc@live.com> - 1.0.2-1
+- Fix secondary monitors going unpainted (windows smear): assert the
+  background actor is visible whenever the extension paints it
+
 * Thu Jun 18 2026 Hector Diaz <hdiazc@live.com> - 1.0.1-1
 - Correct README config example: drop the unused per-monitor "mode" key and a
   nonexistent monitor-listing command


### PR DESCRIPTION
Upstream fix for secondary monitors going unpainted (windows smear); the extension now asserts the background actor is visible whenever it paints it.