### PR TITLE
themes: fix St-rejected keyword background-position in shell CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,17 +9,17 @@ Each subdirectory is one source package.
 | Spec | Current build | What it ships |
 |---|---|---|
 | colloid-gtk-theme | `20250731-5` | GTK theme ([vinceliuice/Colloid-gtk-theme](https://github.com/vinceliuice/Colloid-gtk-theme)), GNOME 50 patches |
-| fluent-gtk-theme-compact | `20250417-6` | GTK theme ([vinceliuice/Fluent-gtk-theme](https://github.com/vinceliuice/Fluent-gtk-theme)), GNOME 50 patches |
+| fluent-gtk-theme-compact | `20250417-7` | GTK theme ([vinceliuice/Fluent-gtk-theme](https://github.com/vinceliuice/Fluent-gtk-theme)), GNOME 50 patches |
 | gnome-shell-extension-per-monitor-wallpaper | `1.0.2-1` | GNOME Shell extension, per-monitor wallpapers ([raro28/per-monitor-wallpaper](https://github.com/raro28/per-monitor-wallpaper)) |
 | llama.cpp | `0^b9544-1` | LLM inference, Vulkan backend + embedded web UI ([ggml-org/llama.cpp](https://github.com/ggml-org/llama.cpp)) |
 | looking-glass-client | `7.0.0-14` | Looking Glass B7 client + SELinux subpackage ([gnif/LookingGlass](https://github.com/gnif/LookingGlass)) |
 | looking-glass-kvmfr-kmod | `0.0.12-7` | akmod for the `kvmfr` kernel module ([gnif/LookingGlass](https://github.com/gnif/LookingGlass)) — see [its README](looking-glass-kvmfr-kmod/README.md) |
-| orchis-theme | `20250425-5` | GTK theme ([vinceliuice/Orchis-theme](https://github.com/vinceliuice/Orchis-theme)), GNOME 50 patches |
+| orchis-theme | `20250425-6` | GTK theme ([vinceliuice/Orchis-theme](https://github.com/vinceliuice/Orchis-theme)), GNOME 50 patches |
 | qogir-icon-theme | `20250215-3` | Icon theme ([vinceliuice/Qogir-icon-theme](https://github.com/vinceliuice/Qogir-icon-theme)) |
 | qogir-theme | `20250817-5` | GTK theme ([vinceliuice/Qogir-theme](https://github.com/vinceliuice/Qogir-theme)), GNOME 50 patches |
 | tela-circle-icon-theme | `20250210-3` | Icon theme ([vinceliuice/Tela-circle-icon-theme](https://github.com/vinceliuice/Tela-circle-icon-theme)) |
 | tela-icon-theme | `20250210-1` | Icon theme ([vinceliuice/Tela-icon-theme](https://github.com/vinceliuice/Tela-icon-theme)) |
-| whitesur-gtk-theme | `20260606-2` | GTK theme ([vinceliuice/WhiteSur-gtk-theme](https://github.com/vinceliuice/WhiteSur-gtk-theme)), GNOME 50 master snapshot + patches |
+| whitesur-gtk-theme | `20260606-3` | GTK theme ([vinceliuice/WhiteSur-gtk-theme](https://github.com/vinceliuice/WhiteSur-gtk-theme)), GNOME 50 master snapshot + patches |
 | whitesur-icon-theme | `20251227-1` | Icon theme ([vinceliuice/WhiteSur-icon-theme](https://github.com/vinceliuice/WhiteSur-icon-theme)) |
 
 ## Host setup (once)
@@ -92,10 +92,10 @@ mock -r fedora-44-x86_64 ~/rpmbuild/SRPMS/qogir-icon-theme-20250215-3.fc44.src.r
 | Spec | Patches |
 |---|---|
 | colloid-gtk-theme | gnome50-selectors, gnome50-appearance, fix-fsf-address |
-| fluent-gtk-theme-compact | gnome50-selectors, gnome50-appearance |
-| orchis-theme | gnome50-selectors, gnome50-appearance, fix-gtk4-define-color |
+| fluent-gtk-theme-compact | gnome50-selectors, gnome50-appearance, fix-shell-bg-position |
+| orchis-theme | gnome50-selectors, gnome50-appearance, fix-gtk4-define-color, fix-shell-bg-position |
 | qogir-theme | gnome50-selectors, gnome50-appearance |
-| whitesur-gtk-theme | gnome50-selectors, gnome50-appearance, fix-fsf-address |
+| whitesur-gtk-theme | gnome50-selectors, gnome50-appearance, fix-fsf-address, fix-shell-bg-position |
 
 Stage the patches with the glob, then build. Example (`qogir-theme`):
 
@@ -112,6 +112,7 @@ Patch reference:
 - `gnome50-appearance.patch` — GNOME 50 native geometry: `.login-dialog-bottom-button-group` 32px/16px, `.message-list-clear-button` `border-radius: 999px`.
 - `fix-fsf-address.patch` (colloid, whitesur) — replaces the outdated FSF postal address in the upstream `gnome-shell.css` GPL header with the canonical URL form (clears rpmlint `incorrect-fsf-address`).
 - `fix-gtk4-define-color.patch` (orchis) — the libadwaita build emitted `@define-color theme_{,unfocused_}selected_bg_color var(--accent-bg-color)`, which GTK's `@define-color` rejects; references the defined `@accent_color` in the libadwaita case only (the GTK3 literal is untouched).
+- `fix-shell-bg-position.patch` (fluent, orchis, whitesur) — the upstream `#panelActivities` rule sets `background-position: center center`, a keyword St's shell CSS engine cannot parse (logged at runtime as `Ignoring length property that isn't a number`); St drops it and falls back to `0 0`, so setting `0 0` explicitly is pixel-identical and silences the warning.
 
 `whitesur-gtk-theme` additionally builds from a pinned `master` snapshot (`%global commit`) rather than the last tag (`20250724`, predates GNOME 49/50), date-versioned `20260606` so a future upstream `YYYYMMDD` tag supersedes it. Advance via `%global commit`.
 
@@ -198,7 +199,7 @@ After installing, `/dev/kvmfr0` needs **two manual host configuration steps** (l
 | 4 vinceliuice icon themes | No | Source0 only |
 | gnome-shell-extension-per-monitor-wallpaper | No | Source0 only |
 | llama.cpp | No | Source0 + Source1 (web-UI bundle) |
-| 5 vinceliuice GTK themes | **Yes** — 2–3 patches | Source0 only |
+| 5 vinceliuice GTK themes | **Yes** — 2–4 patches | Source0 only |
 | looking-glass-client | **Yes** — 4 files | Source0 + 6 submodule URLs |
 | looking-glass-kvmfr-kmod | **Yes** — 5 files + 1 patch | Source0 only |
 

--- a/fluent-gtk-theme/fix-shell-bg-position.patch
+++ b/fluent-gtk-theme/fix-shell-bg-position.patch
@@ -1,0 +1,13 @@
+diff --git a/src/gnome-shell/sass/widgets/_panel.scss b/src/gnome-shell/sass/widgets/_panel.scss
+index 3a0e377..baee119 100644
+--- a/src/gnome-shell/sass/widgets/_panel.scss
++++ b/src/gnome-shell/sass/widgets/_panel.scss
+@@ -5,7 +5,7 @@ $panel_transition_duration: 250ms; // same as the overview transition duration
+ 
+ %activities_icon {
+   background-image: url("assets/activities.svg");
+-  background-position: center center;
++  background-position: 0 0; // GNOME 50: St rejects keyword positions; 0 0 == its fallback (no visual change)
+   background-repeat: no-repeat;
+   background-size: auto;
+   color: transparent !important;

--- a/fluent-gtk-theme/fluent-gtk-theme-compact.spec
+++ b/fluent-gtk-theme/fluent-gtk-theme-compact.spec
@@ -1,6 +1,6 @@
 Name:           fluent-gtk-theme-compact
 Version:        20250417
-Release:        6%{?dist}
+Release:        7%{?dist}
 Summary:        Theme for GNOME/GTK based desktop environments
 BuildArch:      noarch
 
@@ -12,6 +12,11 @@ URL:            https://github.com/vinceliuice/%{dname}
 Source0:        https://github.com/vinceliuice/%{dname}/archive/refs/tags/%{dversion}.tar.gz
 Patch0:         gnome50-selectors.patch
 Patch1:         gnome50-appearance.patch
+# St's shell CSS engine rejects the keyword value in the upstream
+# #panelActivities "background-position: center center" (logged at runtime as
+# "Ignoring length property that isn't a number"). St already falls back to 0 0,
+# so the numeric form is pixel-identical and silences the warning.
+Patch2:         fix-shell-bg-position.patch
 
 BuildRequires:  gnome-shell
 BuildRequires:  sassc
@@ -70,6 +75,16 @@ echo "shell node-gate: OK"
 %{_datarootdir}/themes
 
 %changelog
+* Sun Jun 21 2026 Hector Diaz <hdiazc@live.com> - 20250417-7
+- Patch2 (fix-shell-bg-position): the upstream #panelActivities rule sets
+  "background-position: center center", a keyword St's CSS engine cannot parse —
+  it logs "Ignoring length property that isn't a number" on every theme load and
+  drops the declaration, falling back to 0 0. Set the numeric 0 0 explicitly in
+  the gnome-shell %%activities_icon placeholder. St already rendered at 0 0
+  (background-size: auto), so this is no visual change; silences the runtime
+  warning. Verified: the compiled gnome-shell.css no longer carries a keyword
+  background-position.
+
 * Sun Jun 21 2026 Hector Diaz <hdiazc@live.com> - 20250417-6
 - Patch0 (gnome50-selectors): style the GNOME 50 login .a11y-button and the
   notification .message-list-clear-button with the theme's own button styling

--- a/orchis-theme/fix-shell-bg-position.patch
+++ b/orchis-theme/fix-shell-bg-position.patch
@@ -1,0 +1,13 @@
+diff --git a/src/_sass/gnome-shell/widgets/_panel.scss b/src/_sass/gnome-shell/widgets/_panel.scss
+index 973f266..1630938 100644
+--- a/src/_sass/gnome-shell/widgets/_panel.scss
++++ b/src/_sass/gnome-shell/widgets/_panel.scss
+@@ -51,7 +51,7 @@ $panel_button_hpadding: ($panel_height - $base-icon-size) / 2;
+ 
+   %icon_activities {
+     background-image: url("assets/activities.svg");
+-    background-position: center center;
++    background-position: 0 0; // GNOME 50: St rejects keyword positions; 0 0 == its fallback (no visual change)
+     background-repeat: no-repeat;
+     background-size: 24px 24px;
+     width: 24px;

--- a/orchis-theme/orchis-theme.spec
+++ b/orchis-theme/orchis-theme.spec
@@ -1,6 +1,6 @@
 Name:           orchis-theme
 Version:        20250425
-Release:        5%{?dist}
+Release:        6%{?dist}
 Summary:        Theme for GNOME/GTK based desktop environments
 BuildArch:      noarch
 
@@ -13,6 +13,11 @@ Source0:        https://github.com/vinceliuice/%{dname}/archive/refs/tags/%{dver
 Patch0:         gnome50-selectors.patch
 Patch1:         gnome50-appearance.patch
 Patch2:         fix-gtk4-define-color.patch
+# St's shell CSS engine rejects the keyword value in the upstream
+# #panelActivities "background-position: center center" (logged at runtime as
+# "Ignoring length property that isn't a number"). St already falls back to 0 0,
+# so the numeric form is pixel-identical and silences the warning.
+Patch3:         fix-shell-bg-position.patch
 
 BuildRequires:  gnome-shell
 BuildRequires:  sassc
@@ -72,6 +77,16 @@ echo "shell node-gate: OK"
 %{_datarootdir}/themes
 
 %changelog
+* Sun Jun 21 2026 Hector Diaz <hdiazc@live.com> - 20250425-6
+- Patch3 (fix-shell-bg-position): the upstream #panelActivities rule sets
+  "background-position: center center", a keyword St's CSS engine cannot parse —
+  it logs "Ignoring length property that isn't a number" on every theme load and
+  drops the declaration, falling back to 0 0. Set the numeric 0 0 explicitly in
+  the gnome-shell %%icon_activities placeholder. Pixel-identical (icon size equals
+  the 24px box, and St already rendered at 0 0); silences the runtime warning.
+  Verified: the compiled gnome-shell.css no longer carries a keyword
+  background-position.
+
 * Sun Jun 21 2026 Hector Diaz <hdiazc@live.com> - 20250425-5
 - Patch0 (gnome50-selectors): style the GNOME 50 login .a11y-button and
   notification .message-list-clear-button using the theme's own existing

--- a/whitesur-gtk-theme/fix-shell-bg-position.patch
+++ b/whitesur-gtk-theme/fix-shell-bg-position.patch
@@ -1,0 +1,13 @@
+diff --git a/src/sass/gnome-shell/common/_panel.scss b/src/sass/gnome-shell/common/_panel.scss
+index 3dd5a9c..ea79edd 100644
+--- a/src/sass/gnome-shell/common/_panel.scss
++++ b/src/sass/gnome-shell/common/_panel.scss
+@@ -73,7 +73,7 @@ $panel_height: $menuitem_size;
+ %apple_activites {
+   -natural-hpadding: $base_padding * 2;
+   background-image: url("assets/activities.svg");
+-  background-position: center center;
++  background-position: 0 0; // GNOME 50: St rejects keyword positions; 0 0 == its fallback (no visual change)
+   background-size: 24px 24px;
+   width: 24px;
+   height: 24px;

--- a/whitesur-gtk-theme/whitesur-gtk-theme.spec
+++ b/whitesur-gtk-theme/whitesur-gtk-theme.spec
@@ -11,7 +11,7 @@ Name:           whitesur-gtk-theme
 # below any future upstream YYYYMMDD tag (all dated after today), so real
 # upstream updates still win. dname-shortcommit identifies the actual source.
 Version:        20260606
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Theme for GNOME/GTK based desktop environments
 BuildArch:      noarch
 
@@ -30,6 +30,11 @@ Source0:        https://github.com/vinceliuice/%{dname}/archive/%{commit}.tar.gz
 Patch0:         gnome50-selectors.patch
 Patch1:         gnome50-appearance.patch
 Patch2:         fix-fsf-address.patch
+# St's shell CSS engine rejects the keyword value in the upstream
+# #panelActivities "background-position: center center" (logged at runtime as
+# "Ignoring length property that isn't a number"). St already falls back to 0 0,
+# so the numeric form is pixel-identical and silences the warning.
+Patch3:         fix-shell-bg-position.patch
 
 BuildRequires:  glib2-devel
 BuildRequires:  gnome-shell
@@ -90,6 +95,16 @@ echo "shell node-gate: OK"
 %{_datarootdir}/themes
 
 %changelog
+* Sun Jun 21 2026 Hector Diaz <hdiazc@live.com> - 20260606-3
+- Patch3 (fix-shell-bg-position): the upstream #panelActivities rule sets
+  "background-position: center center", a keyword St's CSS engine cannot parse —
+  it logs "Ignoring length property that isn't a number" on every theme load and
+  drops the declaration, falling back to 0 0. Set the numeric 0 0 explicitly in
+  the gnome-shell %%apple_activites placeholder. Pixel-identical (icon size equals
+  the 24px box, and St already rendered at 0 0); silences the runtime warning.
+  Verified: the compiled gnome-shell.css no longer carries a keyword
+  background-position and the journal warning is gone after install.
+
 * Sun Jun 21 2026 Hector Diaz <hdiazc@live.com> - 20260606-2
 - Split the single GNOME 50 login patch into the uniform two-patch model now
   shared with the other vinceliuice themes (fluent/colloid/qogir):


### PR DESCRIPTION
The upstream #panelActivities rule sets "background-position: center center", a keyword value GNOME Shell's St CSS engine cannot parse. At runtime St logs "Ignoring length property that isn't a number" on every theme load and drops the declaration, falling back to 0 0. Observed live on this GNOME 50.2 host (22x this boot under the active WhiteSur theme; recurring across boots for whichever vinceliuice theme was applied).

Fix downstream in the gnome-shell %placeholder of each affected theme: set the numeric "0 0" explicitly. Pixel-identical (St already rendered at 0 0; for WhiteSur/Orchis the icon equals the 24px box) and silences the warning. Affects fluent, orchis, whitesur; colloid and qogir have no keyword background-position and are unchanged.

fix-shell-bg-position.patch added to each; Release bumped:
  fluent 20250417-6 -> -7, orchis 20250425-5 -> -6,
  whitesur 20260606-2 -> -3.

Verified: mock build exit 0 with %check passing (GTK4 engine 0 errors, shell node-gate OK) for all three; the compiled gnome-shell.css carries no keyword background-position in any installed variant; rpmlint 0/0. README synced (versions, patch table, patch reference, quick-ref count 2-4). Live runtime confirmation occurs on the next shell reload.