### PR TITLE
gnome-shell-extension-per-monitor-wallpaper: 2.2.1 (overview-at-login…

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Each subdirectory is one source package.
 |---|---|---|
 | colloid-gtk-theme | `20250731-5` | GTK theme ([vinceliuice/Colloid-gtk-theme](https://github.com/vinceliuice/Colloid-gtk-theme)), GNOME 50 patches |
 | fluent-gtk-theme-compact | `20250417-7` | GTK theme ([vinceliuice/Fluent-gtk-theme](https://github.com/vinceliuice/Fluent-gtk-theme)), GNOME 50 patches |
-| gnome-shell-extension-per-monitor-wallpaper | `2.2.0-1` | GNOME Shell extension, per-monitor wallpapers; reader-only (editing GUI is `mural`) ([raro28/per-monitor-wallpaper](https://github.com/raro28/per-monitor-wallpaper)) |
+| gnome-shell-extension-per-monitor-wallpaper | `2.2.1-1` | GNOME Shell extension, per-monitor wallpapers; reader-only (editing GUI is `mural`) ([raro28/per-monitor-wallpaper](https://github.com/raro28/per-monitor-wallpaper)) |
 | llama.cpp | `0^b9544-1` | LLM inference, Vulkan backend + embedded web UI ([ggml-org/llama.cpp](https://github.com/ggml-org/llama.cpp)) |
 | looking-glass-client | `7.0.0-14` | Looking Glass B7 client + SELinux subpackage ([gnif/LookingGlass](https://github.com/gnif/LookingGlass)) |
 | looking-glass-kvmfr-kmod | `0.0.12-7` | akmod for the `kvmfr` kernel module ([gnif/LookingGlass](https://github.com/gnif/LookingGlass)) — see [its README](looking-glass-kvmfr-kmod/README.md) |

--- a/gnome-shell-extension-per-monitor-wallpaper/gnome-shell-extension-per-monitor-wallpaper.spec
+++ b/gnome-shell-extension-per-monitor-wallpaper/gnome-shell-extension-per-monitor-wallpaper.spec
@@ -2,7 +2,7 @@
 %global uuid    per-monitor-wallpaper@ekthor
 
 Name:           gnome-shell-extension-per-monitor-wallpaper
-Version:        2.2.0
+Version:        2.2.1
 Release:        1%{?dist}
 Summary:        GNOME Shell extension that paints each monitor its own wallpaper
 BuildArch:      noarch
@@ -46,6 +46,11 @@ install -pm 0644 metadata.json extension.js \
 %{_datadir}/gnome-shell/extensions/%{uuid}/
 
 %changelog
+* Thu Jul 09 2026 Hector Diaz <hdiazc@live.com> - 2.2.1-1
+- Paint per-monitor wallpapers when the session opens in the overview; a system-wide
+  install enabled after the overview was shown, leaving GNOME's single wallpaper on
+  every monitor until the overview was dismissed
+
 * Sat Jun 27 2026 Hector Diaz <hdiazc@live.com> - 2.2.0-1
 - Remove the bundled preferences UI; the editing GUI is now the standalone mural app. Reader-only extension.
 


### PR DESCRIPTION
… fix)

Upstream fix: a system-wide install enables after GNOME has shown the startup overview, so the extension never overrode the overview's background actors and GNOME's single wallpaper stayed on every monitor until the overview was dismissed.

mock exit 0; rpmlint -c rpmlint.toml */*.spec => 0 errors, 0 warnings.