### PR TITLE
llama.cpp: b9965 + split into base/-vulkan/-rocm backend subpackages

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Each subdirectory is one source package.
 | colloid-gtk-theme | `20250731-5` | GTK theme ([vinceliuice/Colloid-gtk-theme](https://github.com/vinceliuice/Colloid-gtk-theme)), GNOME 50 patches |
 | fluent-gtk-theme-compact | `20250417-7` | GTK theme ([vinceliuice/Fluent-gtk-theme](https://github.com/vinceliuice/Fluent-gtk-theme)), GNOME 50 patches |
 | gnome-shell-extension-per-monitor-wallpaper | `2.2.1-1` | GNOME Shell extension, per-monitor wallpapers; reader-only (editing GUI is `mural`) ([raro28/per-monitor-wallpaper](https://github.com/raro28/per-monitor-wallpaper)) |
-| llama.cpp | `0^b9544-1` | LLM inference, Vulkan backend + embedded web UI ([ggml-org/llama.cpp](https://github.com/ggml-org/llama.cpp)) |
+| llama.cpp | `0^b9965-1` | LLM inference, CPU engine + embedded web UI; GPU via `-vulkan`/`-rocm` backend subpackages ([ggml-org/llama.cpp](https://github.com/ggml-org/llama.cpp)) |
 | looking-glass-client | `7.0.0-14` | Looking Glass B7 client + SELinux subpackage ([gnif/LookingGlass](https://github.com/gnif/LookingGlass)) |
 | looking-glass-kvmfr-kmod | `0.0.12-7` | akmod for the `kvmfr` kernel module ([gnif/LookingGlass](https://github.com/gnif/LookingGlass)) — see [its README](looking-glass-kvmfr-kmod/README.md) |
 | mural | `1.0.2-1` | Per-monitor wallpaper editor, standalone GTK4/libadwaita app ([raro28/mural](https://github.com/raro28/mural)) |
@@ -128,12 +128,20 @@ Patch reference:
 
 ### llama.cpp
 
-No local sources, but two URL sources: `Source0` (the source tarball) and `Source1` (the prebuilt `llama-bNNNN-ui.tar.gz` web-UI bundle from the matching GitHub release, extracted into `tools/ui/dist` during `%prep` so the server embeds the SvelteKit UI without pulling in nodejs/npm at build time). `spectool -g -R` fetches both. Ships `llama-cli`, `llama-server` (with the web UI), `llama-bench`, `llama-quantize` etc. with the Vulkan backend enabled. Runtime needs a Vulkan ICD (`mesa-vulkan-drivers` for AMD/Intel; NVIDIA's proprietary driver provides one).
+No local sources, but two URL sources: `Source0` (the source tarball) and `Source1` (the prebuilt `llama-bNNNN-ui.tar.gz` web-UI bundle from the matching GitHub release, extracted into `tools/ui/dist` during `%prep` so the server embeds the SvelteKit UI without pulling in nodejs/npm at build time). `spectool -g -R` fetches both.
+
+One SRPM builds three coexisting binary RPMs off the `GGML_BACKEND_DL` module layout (`-DGGML_VULKAN=ON -DGGML_HIP=ON` in a single pass):
+
+- **`llama.cpp`** (base) — `llama-cli`, `llama-server` (with web UI), `llama-bench`, `llama-quantize` etc. plus the CPU backend (all x86-64 variants, runtime-dispatched). No GPU dependency; `Recommends: llama.cpp-vulkan` so a bare install stays GPU-accelerated.
+- **`llama.cpp-vulkan`** — the `libggml-vulkan.so` dlopen module; `Recommends: mesa-vulkan-drivers` (RADV/ANV for AMD/Intel, NVIDIA proprietary). Portable across vendors.
+- **`llama.cpp-rocm`** — the `libggml-hip.so` dlopen module built for `AMDGPU_TARGETS=gfx1030` (RDNA2, RX 6800/6900 XT); auto-pulls rocBLAS/hipBLAS. The gfx1030 kernels compile ahead-of-time from the ISA string, so no GPU is needed to build (or in COPR).
+
+ggml loads whichever backend modules are installed and enumerates all their devices; the backends coexist, and RPM's soname-based dep generation isolates each GPU stack to its own subpackage. The `-rocm` gfx target is a one-line `%global amdgpu_targets` macro.
 
 ```bash
 spectool -g -R llama.cpp/llama.cpp.spec
 rpmbuild -bs llama.cpp/llama.cpp.spec
-mock -r fedora-44-x86_64 ~/rpmbuild/SRPMS/llama.cpp-0\^b9544-1.fc44.src.rpm
+mock -r fedora-44-x86_64 ~/rpmbuild/SRPMS/llama.cpp-0\^b9965-1.fc44.src.rpm
 ```
 
 **Note the `\^` shell-escape** when typing the SRPM filename — `^` is the Fedora-standard post-release snapshot marker (upstream tags are `bNNNN` build numbers, no semver), and the literal caret appears in the filename.

--- a/llama.cpp/llama.cpp.spec
+++ b/llama.cpp/llama.cpp.spec
@@ -1,10 +1,14 @@
-%global build_num     9828
-%global upstream_tag  b%{build_num}
+%global build_num       9965
+%global upstream_tag    b%{build_num}
+# AMD GPU ISA target(s) for the ROCm/HIP backend. gfx1030 = RDNA2 (RX 6800/6900
+# XT); Fedora's rocBLAS ships Tensile kernels for it. Add space-separated targets
+# here to widen -rocm coverage (each adds build time).
+%global amdgpu_targets  gfx1030
 
 Name:           llama.cpp
 Version:        0^b%{build_num}
 Release:        1%{?dist}
-Summary:        LLM inference in C/C++ (Vulkan-accelerated build)
+Summary:        LLM inference in C/C++ (CPU engine; GPU backends packaged separately)
 
 # Upstream is MIT. Bundled third-party code under the same or compatible
 # permissive terms (see LICENSE and ggml/ for details).
@@ -22,28 +26,65 @@ BuildRequires:  gcc
 BuildRequires:  gcc-c++
 BuildRequires:  git
 BuildRequires:  pkgconf-pkg-config
+# Vulkan backend
 BuildRequires:  vulkan-loader-devel
 BuildRequires:  vulkan-headers
 BuildRequires:  glslc
 BuildRequires:  glslang
 BuildRequires:  spirv-headers-devel
+# ROCm/HIP backend (compiles the gfx1030 device kernels; no GPU needed to build)
+BuildRequires:  rocm-hip-devel
+BuildRequires:  hipblas-devel
+BuildRequires:  rocblas-devel
+BuildRequires:  rocm-comgr-devel
+BuildRequires:  rocm-cmake
+BuildRequires:  clang
+BuildRequires:  llvm
+# common
 BuildRequires:  libcurl-devel
 # Activates LLAMA_OPENSSL (default ON): HTTPS support in the server's httplib client.
 BuildRequires:  openssl-devel
 
-Requires:       vulkan-loader
+# Base is the CPU engine + shared binaries; GPU acceleration is delivered by the
+# -vulkan / -rocm backend subpackages, each a single dlopen module ggml discovers
+# at runtime. Recommend the portable Vulkan backend so a bare `dnf install
+# llama.cpp` stays GPU-accelerated by default (weak dep: droppable on CPU-only hosts).
+Recommends:     %{name}-vulkan = %{version}-%{release}
+
+%description
+llama.cpp is a plain-C/C++ implementation of LLM inference with minimal
+dependencies, supporting GGUF model files. This base package provides the CPU
+inference engine (every x86-64 micro-architecture variant, runtime-dispatched)
+and the shared binaries: llama-cli, llama-server, llama-bench, llama-quantize,
+llama-tokenize, and friends.
+
+GPU acceleration is optional and delivered by separate backend packages that
+ggml loads at runtime when installed:
+  * llama.cpp-vulkan -- portable Vulkan backend (Mesa RADV/ANV, NVIDIA)
+  * llama.cpp-rocm   -- AMD ROCm/HIP backend (gfx1030 / RDNA2)
+
+%package vulkan
+Summary:        Vulkan GPU backend for llama.cpp
+Requires:       %{name} = %{version}-%{release}
 # Runtime needs a Vulkan ICD. On AMD/Intel that's Mesa's RADV/ANV
 # (mesa-vulkan-drivers); on NVIDIA the proprietary driver provides one.
 Recommends:     mesa-vulkan-drivers
 
-%description
-llama.cpp is a plain-C/C++ implementation of LLM inference with minimal
-dependencies, supporting GGUF model files. This package ships the
-Vulkan-accelerated build, which runs on any GPU with a Vulkan driver
-(Mesa RADV for AMD/Intel, NVIDIA's proprietary driver).
+%description vulkan
+Vulkan compute backend for llama.cpp (libggml-vulkan.so). Runs on any GPU with a
+Vulkan driver -- Mesa RADV/ANV for AMD/Intel, NVIDIA's proprietary driver. ggml
+discovers and loads it at runtime; install alongside the llama.cpp base package.
+Portable across GPU vendors.
 
-Includes the standard binaries: llama-cli, llama-server, llama-bench,
-llama-quantize, llama-tokenize, and friends.
+%package rocm
+Summary:        ROCm/HIP GPU backend for llama.cpp (AMD gfx1030)
+Requires:       %{name} = %{version}-%{release}
+
+%description rocm
+ROCm/HIP compute backend for llama.cpp (libggml-hip.so), compiled for AMD
+gfx1030 (RDNA2 -- e.g. Radeon RX 6800/6800 XT/6900 XT). Pulls in rocBLAS and
+hipBLAS. ggml discovers and loads it at runtime; install alongside the llama.cpp
+base package. AMD-only and specific to the gfx1030 target.
 
 %prep
 %autosetup -n llama.cpp-%{upstream_tag}
@@ -53,8 +94,12 @@ mkdir -p tools/ui/dist
 tar xf %{SOURCE1} --strip-components=1 -C tools/ui/dist
 
 %build
+# One pass builds all three backends as GGML_BACKEND_DL dlopen modules:
+# libggml-cpu-*.so (base), libggml-vulkan.so (-vulkan), libggml-hip.so (-rocm).
 %cmake \
     -DGGML_VULKAN=ON \
+    -DGGML_HIP=ON \
+    -DAMDGPU_TARGETS=%{amdgpu_targets} \
     -DGGML_NATIVE=OFF \
     -DGGML_LTO=ON \
     -DGGML_BACKEND_DL=ON \
@@ -81,22 +126,62 @@ find %{buildroot}%{_libdir} -maxdepth 1 -type l -name '*.so' -delete
 test -x %{buildroot}%{_bindir}/llama-cli
 test -x %{buildroot}%{_bindir}/llama-server
 test -x %{buildroot}%{_bindir}/llama-bench
+# All three backends must have built as their own dlopen modules:
+test -f %{buildroot}%{_bindir}/libggml-vulkan.so
+test -f %{buildroot}%{_bindir}/libggml-hip.so
+ls %{buildroot}%{_bindir}/libggml-cpu-*.so >/dev/null
 
 %files
 %license LICENSE
 %doc README.md
 %{_bindir}/llama
 %{_bindir}/llama-*
-# Backend libs land in _bindir (not _libdir) with GGML_BACKEND_DL=ON so the
-# main binaries can dlopen them via $ORIGIN-relative search.
-%{_bindir}/libggml-*.so
+# CPU backend modules land in _bindir (not _libdir) with GGML_BACKEND_DL=ON so
+# the main binaries dlopen them via $ORIGIN-relative search. GPU backend modules
+# ship in the -vulkan / -rocm subpackages.
+%{_bindir}/libggml-cpu-*.so
 %{_libdir}/libllama*.so.*
 %{_libdir}/libggml*.so.*
 %{_libdir}/libmtmd.so.*
 # Private impl libs (sonameless regular files, runtime-NEEDED by the launchers).
 %{_libdir}/libllama-*-impl.so
 
+%files vulkan
+%license LICENSE
+%{_bindir}/libggml-vulkan.so
+
+%files rocm
+%license LICENSE
+%{_bindir}/libggml-hip.so
+
 %changelog
+* Sat Jul 11 2026 Hector Diaz <hdiazc@live.com> - 0^b9965-1
+- Rebase to upstream tag b9965 (137 builds from b9828). Build-option surface
+  verified unchanged against the b9828..b9965 CMake source: root CMakeLists has
+  no option diff; ggml only bumped its version and added the OFF-by-default
+  GGML_ET backend (unused). All existing flags behave the same.
+- Split into backend subpackages using the existing GGML_BACKEND_DL layout, built
+  in one pass (-DGGML_VULKAN=ON -DGGML_HIP=ON):
+  * llama.cpp (base): binaries + core libs + the CPU backend (all x86-64
+    variants). No GPU dependency. Recommends %%{name}-vulkan so a default install
+    stays GPU-accelerated.
+  * llama.cpp-vulkan: the libggml-vulkan.so dlopen module (NEEDED: libvulkan);
+    Recommends mesa-vulkan-drivers.
+  * llama.cpp-rocm: the libggml-hip.so dlopen module built for
+    AMDGPU_TARGETS=gfx1030 (NEEDED: rocblas/hipblas/amdhip64).
+  The three modules coexist; ggml loads whichever are installed and enumerates
+  all their devices. Verified from the built artifacts that each backend module
+  NEEDs only its own GPU stack and the core/binaries carry no GPU linkage, so
+  RPM's soname-based dep generation isolates rocBLAS to -rocm and Vulkan to
+  -vulkan automatically.
+- Add the ROCm/HIP build toolchain to BuildRequires (rocm-hip-devel,
+  hipblas-devel, rocblas-devel, rocm-comgr-devel, rocm-cmake, clang, llvm). The
+  gfx1030 kernels compile ahead-of-time from the ISA string; no GPU is needed at
+  build time (proven in a GPU-less mock chroot).
+- NOTE: -rocm is build-verified only. Its gfx1030 target (RX 6900 XT) is bound to
+  vfio-pci on the build host, so runtime performance is not yet measured;
+  Vulkan-vs-ROCm benchmarking is deferred until the card is available to the host.
+
 * Sat Jun 27 2026 Hector Diaz <hdiazc@live.com> - 0^b9828-1
 - Rebase to upstream tag b9828 (284 commits from b9544). Pure version bump;
   build flags verified unchanged against the b9828 CMake source.

--- a/rpmlint.toml
+++ b/rpmlint.toml
@@ -19,8 +19,9 @@
 # these packages expose a typelib() provide to depend on instead. The check is a
 # false positive here.
 #
-# spelling-error cli: false positive -- the llama-cli tool name in llama.cpp's
-# %description (rpmlint wants "CLI").
+# spelling-error cli/ggml/vulkan/rocm/...: false positives -- the llama-cli tool
+# name plus the backend/GPU technical terms in llama.cpp's %description(s)
+# (ggml, libggml, vulkan, rocm, rocBLAS, hipBLAS, Radeon). All correct spellings.
 #
 # invalid-soname (llama.cpp): upstream's unified-binary private impl libs
 # (libllama-*-impl.so) are runtime-NEEDED regular files that carry no SONAME, and
@@ -30,10 +31,15 @@
 # no-manual-page (llama.cpp): upstream ships no man pages for its 40+ llama-* tools
 # or the dlopen backend libs (libggml-*.so); authoring them is impractical. Scoped
 # by binary-name prefix so it does not suppress the check repo-wide.
+#
+# no-documentation (llama.cpp-vulkan/-rocm): the GPU backend subpackages ship a
+# single dlopen module (libggml-vulkan.so / libggml-hip.so) and Require the base
+# package, where README/LICENSE live. No own docs by design. Scoped to those two.
 Filters = [
     "no-%check-section",
-    "spelling-error.*'(json|ekthor|cli)'",
+    "spelling-error.*'(json|ekthor|cli|ggml|libggml|vulkan|rocm|rocBLAS|hipBLAS|Radeon)'",
     "explicit-lib-dependency (libadwaita|glycin-libs|glycin-gtk4-libs)",
     "invalid-soname .*libllama-.*-impl\\.so",
     "no-manual-page-for-binary (llama|libggml-)",
+    "llama\\.cpp-(vulkan|rocm).*no-documentation",
 ]


### PR DESCRIPTION
Bump b9828->b9965 (build-option surface verified unchanged: root CMakeLists no diff; ggml only added the OFF-by-default GGML_ET backend).

Split the single Vulkan package into three coexisting RPMs off the existing GGML_BACKEND_DL module layout, built in one pass (-DGGML_VULKAN=ON -DGGML_HIP=ON, AMDGPU_TARGETS=gfx1030):
  * llama.cpp (base): binaries + core + CPU backend, no GPU deps, Recommends llama.cpp-vulkan.
  * llama.cpp-vulkan: libggml-vulkan.so (NEEDED: libvulkan).
  * llama.cpp-rocm: libggml-hip.so for gfx1030 (NEEDED: rocblas/hipblas/amdhip).

Verified on this host: each module NEEDs only its own GPU stack and the core/binaries carry no GPU linkage, so RPM's soname dep generation isolates rocBLAS to -rocm and Vulkan to -vulkan automatically; all three install and coexist; llama-bench runs Vulkan inference on the RX 6400 with the -rocm module also loaded (backend list "ROCm,Vulkan"). gfx1030 kernels compile in a GPU-less mock chroot (no card needed to build).

-rocm is build-verified only: its gfx1030 target (RX 6900 XT) is on vfio-pci on this host, so runtime perf is deferred until the card is host-available.

rpmlint.toml: filter spelling-error on backend/GPU technical terms and no-documentation on the two single-module GPU subpackages (documented rationale). Spec + all three binary RPMs lint 0/0.