### PR TITLE
llama.cpp: b10068 + GPU_TARGETS/LLAMA_BUILD_UI flag hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Each subdirectory is one source package.
 | colloid-gtk-theme | `20250731-5` | GTK theme ([vinceliuice/Colloid-gtk-theme](https://github.com/vinceliuice/Colloid-gtk-theme)), GNOME 50 patches |
 | fluent-gtk-theme-compact | `20250417-7` | GTK theme ([vinceliuice/Fluent-gtk-theme](https://github.com/vinceliuice/Fluent-gtk-theme)), GNOME 50 patches |
 | gnome-shell-extension-per-monitor-wallpaper | `2.2.1-1` | GNOME Shell extension, per-monitor wallpapers; reader-only (editing GUI is `mural`) ([raro28/per-monitor-wallpaper](https://github.com/raro28/per-monitor-wallpaper)) |
-| llama.cpp | `0^b9965-1` | LLM inference, CPU engine + embedded web UI; GPU via `-vulkan`/`-rocm` backend subpackages ([ggml-org/llama.cpp](https://github.com/ggml-org/llama.cpp)) |
+| llama.cpp | `0^b10068-1` | LLM inference, CPU engine + embedded web UI; GPU via `-vulkan`/`-rocm` backend subpackages ([ggml-org/llama.cpp](https://github.com/ggml-org/llama.cpp)) |
 | looking-glass-client | `7.0.0-14` | Looking Glass B7 client + SELinux subpackage ([gnif/LookingGlass](https://github.com/gnif/LookingGlass)) |
 | looking-glass-kvmfr-kmod | `0.0.12-7` | akmod for the `kvmfr` kernel module ([gnif/LookingGlass](https://github.com/gnif/LookingGlass)) — see [its README](looking-glass-kvmfr-kmod/README.md) |
 | mural | `1.0.2-1` | Per-monitor wallpaper editor, standalone GTK4/libadwaita app ([raro28/mural](https://github.com/raro28/mural)) |
@@ -134,14 +134,14 @@ One SRPM builds three coexisting binary RPMs off the `GGML_BACKEND_DL` module la
 
 - **`llama.cpp`** (base) — `llama-cli`, `llama-server` (with web UI), `llama-bench`, `llama-quantize` etc. plus the CPU backend (all x86-64 variants, runtime-dispatched). No GPU dependency; `Recommends: llama.cpp-vulkan` so a bare install stays GPU-accelerated.
 - **`llama.cpp-vulkan`** — the `libggml-vulkan.so` dlopen module; `Recommends: mesa-vulkan-drivers` (RADV/ANV for AMD/Intel, NVIDIA proprietary). Portable across vendors.
-- **`llama.cpp-rocm`** — the `libggml-hip.so` dlopen module built for `AMDGPU_TARGETS=gfx1030` (RDNA2, RX 6800/6900 XT); auto-pulls rocBLAS/hipBLAS. The gfx1030 kernels compile ahead-of-time from the ISA string, so no GPU is needed to build (or in COPR).
+- **`llama.cpp-rocm`** — the `libggml-hip.so` dlopen module built for `GPU_TARGETS=gfx1030` (RDNA2, RX 6800/6900 XT); auto-pulls rocBLAS/hipBLAS. The gfx1030 kernels compile ahead-of-time from the ISA string, so no GPU is needed to build (or in COPR).
 
 ggml loads whichever backend modules are installed and enumerates all their devices; the backends coexist, and RPM's soname-based dep generation isolates each GPU stack to its own subpackage. The `-rocm` gfx target is a one-line `%global amdgpu_targets` macro.
 
 ```bash
 spectool -g -R llama.cpp/llama.cpp.spec
 rpmbuild -bs llama.cpp/llama.cpp.spec
-mock -r fedora-44-x86_64 ~/rpmbuild/SRPMS/llama.cpp-0\^b9965-1.fc44.src.rpm
+mock -r fedora-44-x86_64 ~/rpmbuild/SRPMS/llama.cpp-0\^b10068-1.fc44.src.rpm
 ```
 
 **Note the `\^` shell-escape** when typing the SRPM filename — `^` is the Fedora-standard post-release snapshot marker (upstream tags are `bNNNN` build numbers, no semver), and the literal caret appears in the filename.

--- a/llama.cpp/llama.cpp.spec
+++ b/llama.cpp/llama.cpp.spec
@@ -1,4 +1,4 @@
-%global build_num       9965
+%global build_num       10068
 %global upstream_tag    b%{build_num}
 # AMD GPU ISA target(s) for the ROCm/HIP backend. gfx1030 = RDNA2 (RX 6800/6900
 # XT); Fedora's rocBLAS ships Tensile kernels for it. Add space-separated targets
@@ -99,13 +99,14 @@ tar xf %{SOURCE1} --strip-components=1 -C tools/ui/dist
 %cmake \
     -DGGML_VULKAN=ON \
     -DGGML_HIP=ON \
-    -DAMDGPU_TARGETS=%{amdgpu_targets} \
+    -DGPU_TARGETS=%{amdgpu_targets} \
     -DGGML_NATIVE=OFF \
     -DGGML_LTO=ON \
     -DGGML_BACKEND_DL=ON \
     -DGGML_CPU_ALL_VARIANTS=ON \
     -DLLAMA_BUILD_TESTS=OFF \
     -DLLAMA_BUILD_SERVER=ON \
+    -DLLAMA_BUILD_UI=ON \
     -DLLAMA_USE_PREBUILT_UI=ON \
     -DLLAMA_BUILD_NUMBER=%{build_num} \
     -DLLAMA_CURL=ON \
@@ -155,6 +156,26 @@ ls %{buildroot}%{_bindir}/libggml-cpu-*.so >/dev/null
 %{_bindir}/libggml-hip.so
 
 %changelog
+* Sat Jul 18 2026 Hector Diaz <hdiazc@live.com> - 0^b10068-1
+- Rebase to upstream tag b10068 (103 commits from b9965). Pure version bump;
+  build-option surface verified unchanged against the b9965..b10068 CMake source:
+  root CMakeLists.txt has no diff at all, ggml/CMakeLists.txt only bumps
+  GGML_VERSION_MINOR 16->17, and scripts/ui-assets.cmake + tools/ui/CMakeLists.txt
+  are unchanged (UI staging path intact). Commit volume is concentrated in
+  backends we do not build (opencl, sycl, cuda, metal, hexagon).
+- Switch -DAMDGPU_TARGETS to -DGPU_TARGETS: upstream no longer declares an
+  option() for AMDGPU_TARGETS; it survives only as a back-compat forward in
+  ggml/src/ggml-hip/CMakeLists.txt (AMDGPU_TARGETS -> GPU_TARGETS ->
+  CMAKE_HIP_ARCHITECTURES). GPU_TARGETS is the canonical spelling; same gfx1030
+  result without depending on the shim.
+- Pin -DLLAMA_BUILD_UI=ON. LLAMA_USE_PREBUILT_UI is documented upstream as
+  "requires LLAMA_BUILD_UI=ON"; that prerequisite defaults ON but was unpinned,
+  leaving the embedded-UI path one default-flip away from the silent 404 server
+  regression fixed in 0^b9305-3. Both halves are now explicit.
+- New upstream Vulkan glslc capability probes (GL_EXT_float_e2m1 / _e4m3) are
+  auto-detected, not user options: unsupported glslc simply leaves the defines
+  unset. No spec change needed.
+
 * Sat Jul 11 2026 Hector Diaz <hdiazc@live.com> - 0^b9965-1
 - Rebase to upstream tag b9965 (137 builds from b9828). Build-option surface
   verified unchanged against the b9828..b9965 CMake source: root CMakeLists has


### PR DESCRIPTION
Rebase to upstream tag b10068 (103 commits from b9965). Build-option surface verified unchanged: root CMakeLists.txt has no diff, ggml/CMakeLists.txt only bumps GGML_VERSION_MINOR 16->17, ui-assets.cmake and tools/ui/CMakeLists.txt are unchanged. Commit volume is concentrated in backends we do not build (opencl, sycl, cuda, metal, hexagon).

Switch -DAMDGPU_TARGETS to -DGPU_TARGETS: upstream no longer declares an option() for AMDGPU_TARGETS, it survives only as a back-compat forward in ggml/src/ggml-hip/CMakeLists.txt. Verified in the mock build log that -DGPU_TARGETS=gfx1030 reaches clang++ as --offload-arch=gfx1030, and that the shipped libggml-hip.so carries gfx1030 code objects.

Pin -DLLAMA_BUILD_UI=ON. LLAMA_USE_PREBUILT_UI is documented upstream as "requires LLAMA_BUILD_UI=ON"; that prerequisite defaults ON but was unpinned, leaving the embedded-UI path one default-flip away from the silent 404 server regression fixed in 0^b9305-3.

Verified: mock fedora-44-x86_64 exit 0 (9m22s), all 8 RPMs built, %check passed. rpmlint 0 errors 0 warnings on both the specfiles and the 8 binary RPMs.