### PR TITLE
looking-glass-kvmfr-kmod: fix akmodsbuild selinux dep + document install

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ package lives in `<category>/<spec-dir>/`.
 | apps/gnome-shell-extension-per-monitor-wallpaper | `2.2.1-1` | GNOME Shell extension, per-monitor wallpapers; reader-only (editing GUI is `mural`) ([raro28/per-monitor-wallpaper](https://github.com/raro28/per-monitor-wallpaper)) |
 | apps/llama.cpp | `0^b10333-1` | LLM inference, CPU engine + embedded web UI; GPU via `-vulkan`/`-rocm` backend subpackages ([ggml-org/llama.cpp](https://github.com/ggml-org/llama.cpp)) |
 | apps/looking-glass-client | `7.0.0-14` | Looking Glass B7 client + SELinux subpackage ([gnif/LookingGlass](https://github.com/gnif/LookingGlass)) |
-| kernel/looking-glass-kvmfr-kmod | `0.0.12-7` | akmod for the `kvmfr` kernel module ([gnif/LookingGlass](https://github.com/gnif/LookingGlass)) — see [its README](kernel/looking-glass-kvmfr-kmod/README.md) |
+| kernel/looking-glass-kvmfr-kmod | `0.0.12-8` | akmod for the `kvmfr` kernel module ([gnif/LookingGlass](https://github.com/gnif/LookingGlass)) — see [its README](kernel/looking-glass-kvmfr-kmod/README.md) |
 | apps/mural | `1.0.2-1` | Per-monitor wallpaper editor, standalone GTK4/libadwaita app ([raro28/mural](https://github.com/raro28/mural)) |
 | themes/orchis-gtk-theme | `20260707-3` | GTK theme ([vinceliuice/Orchis-theme](https://github.com/vinceliuice/Orchis-theme)), GNOME 50 patches; ships blue, blue-compact, red, red-compact, grey, grey-compact |
 | themes/qogir-gtk-theme | `20250817-7` | GTK theme ([vinceliuice/Qogir-theme](https://github.com/vinceliuice/Qogir-theme)), GNOME 50 patches; single package, no color subpackages (`-t` selects distro branding, not an accent) |
@@ -223,7 +223,7 @@ cp kernel/looking-glass-kvmfr-kmod/{kvmfr.conf,99-kvmfr.rules,kvmfr.te,kvmfr.fc,
    ~/rpmbuild/SOURCES/
 spectool -g -R kernel/looking-glass-kvmfr-kmod/looking-glass-kvmfr-kmod.spec
 rpmbuild -bs kernel/looking-glass-kvmfr-kmod/looking-glass-kvmfr-kmod.spec
-mock -r fedora-44-x86_64 ~/rpmbuild/SRPMS/looking-glass-kvmfr-kmod-0.0.12-7.fc44.src.rpm
+mock -r fedora-44-x86_64 ~/rpmbuild/SRPMS/looking-glass-kvmfr-kmod-0.0.12-8.fc44.src.rpm
 ```
 
 After installing, `/dev/kvmfr0` needs **two manual host configuration steps** (libvirt cgroup ACL + VM XML cutover) the package cannot do for you — see [kernel/looking-glass-kvmfr-kmod/README.md](kernel/looking-glass-kvmfr-kmod/README.md) for the full setup, verification, rollback, and SELinux details.

--- a/kernel/looking-glass-kvmfr-kmod/README.md
+++ b/kernel/looking-glass-kvmfr-kmod/README.md
@@ -19,6 +19,28 @@ The `.ko` itself is **not built in COPR**. `akmod-kvmfr` ships source; the
 `akmods` service rebuilds it on your machine against your installed kernel
 and re-runs automatically after every `dnf update kernel`.
 
+## Installing
+
+```bash
+sudo dnf copr enable raro28/wdm
+sudo dnf install akmod-kvmfr
+sudo akmods --force            # build now; otherwise built on next boot
+```
+
+Install `akmod-kvmfr`, **not** `looking-glass-kvmfr-kmod` — the latter name
+matches only the source RPM (arch `src`) and installs nothing usable.
+`akmod-kvmfr` transitively pulls the entire build chain: `akmods` (whose
+`kernel-devel-matched` boolean dep installs the `kernel-devel` matching your
+running kernel), the toolchain (`gcc`, `make`, `elfutils-libelf-devel`,
+`kmodtool`), `selinux-policy-devel` (to compile `kvmfr.pp`), and
+`kvmfr-kmod-common`. It Recommends `kvmfr-kmod-selinux` and
+`looking-glass-client`, so both come along unless weak deps are disabled.
+Nothing else need be installed by hand.
+
+Requires `akmod-kvmfr >= 0.0.12-8`; earlier builds omit the
+`selinux-policy-devel` dependency, so `akmods` fails to build until it is
+installed manually.
+
 ## What's automated for you
 
 On `dnf install` / upgrade:

--- a/kernel/looking-glass-kvmfr-kmod/looking-glass-kvmfr-kmod.spec
+++ b/kernel/looking-glass-kvmfr-kmod/looking-glass-kvmfr-kmod.spec
@@ -3,7 +3,7 @@
 
 # Pulled in as Requires on akmod-<name> via kmodtool, so that akmodsbuild
 # on the user's machine has the same BR set as the COPR/mock build.
-%global AkmodsBuildRequires kernel-rpm-macros systemd-rpm-macros gcc make elfutils-libelf-devel
+%global AkmodsBuildRequires kernel-rpm-macros systemd-rpm-macros gcc make elfutils-libelf-devel selinux-policy-devel
 
 %global upstream_tag     B7
 %global kmod_name        kvmfr
@@ -12,7 +12,7 @@
 Name:           looking-glass-kvmfr-kmod
 Summary:        Looking Glass KVMFR shared-memory kernel module (akmod)
 Version:        0.0.12
-Release:        7%{?dist}
+Release:        8%{?dist}
 License:        GPL-2.0-or-later
 
 URL:            https://looking-glass.io/
@@ -150,6 +150,14 @@ fi
 %{_datadir}/selinux/packages/%{kmod_name}.pp
 
 %changelog
+* Sun Aug 09 2026 Hector Diaz <hdiazc@live.com> - 0.0.12-8
+- Add selinux-policy-devel to AkmodsBuildRequires. %%build compiles the SELinux
+  .pp unconditionally (make -f /usr/share/selinux/devel/Makefile), so akmodsbuild
+  on the user's machine needs it too. It was omitted when the SELinux subpackage
+  was added in -6, so akmods failed with "selinux-policy-devel is needed by
+  looking-glass-kvmfr-kmod" on hosts without it installed. akmod-kvmfr now pulls
+  it in alongside the other akmodsbuild deps.
+
 * Sat May 16 2026 Hector Diaz <hdiazc@live.com> - 0.0.12-7
 - Ship %%{_modulesloaddir}/kvmfr.conf so systemd-modules-load.service
   auto-loads kvmfr at boot. VMs that depend on /dev/kvmfr0 no longer need


### PR DESCRIPTION
Two commits:

- **`c143f6d`** — add `selinux-policy-devel` to `%global AkmodsBuildRequires`. `%build` compiles the SELinux `.pp` unconditionally, so akmodsbuild on the user's machine needs it too; it was omitted when the SELinux subpackage was added in `-6`, causing `akmods --force` to fail with *"selinux-policy-devel is needed by looking-glass-kvmfr-kmod"*. Release `7 → 8`. Verified: mock exit 0, `akmod-kvmfr-0.0.12-8` now Requires `selinux-policy-devel`, spec lints 0/0.
- **`2696719`** — document the install in the subdir README: use `akmod-kvmfr` (not `looking-glass-kvmfr-kmod`, which is only the src RPM); it transitively pulls akmods + matching kernel-devel, the toolchain, `selinux-policy-devel`, and `kvmfr-kmod-common`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)